### PR TITLE
Correct exit criteria from cli

### DIFF
--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauTestCliConfig.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauTestCliConfig.groovy
@@ -31,6 +31,8 @@ class WebTauTestCliConfig {
 
     private WebTauConfig cfg = WebTauConfig.INSTANCE
 
+    private final ExitHandler exitHandler
+
     private List<String> testFiles
     private String env
     private Path configPath
@@ -38,6 +40,11 @@ class WebTauTestCliConfig {
     private ConfigObject configObject
 
     WebTauTestCliConfig(String... args) {
+        this({ System.exit(it) }, args)
+    }
+
+    WebTauTestCliConfig(ExitHandler exitHandler, String... args) {
+        this.exitHandler = exitHandler
         parseArgs(args)
     }
 
@@ -75,10 +82,11 @@ class WebTauTestCliConfig {
         Options options = createOptions()
         commandLine = createCommandLine(args, options)
 
-        if (commandLine.hasOption("help") || args.length < 1) {
+        if (commandLine.hasOption("help") || commandLine.argList.isEmpty()) {
             HelpFormatter helpFormatter = new HelpFormatter()
             helpFormatter.printHelp("webtau [options] [testFile1] [testFile2]", options)
-            System.exit(1)
+            exitHandler.exit(1)
+            return
         }
 
         testFiles = new ArrayList<>(commandLine.argList)
@@ -114,5 +122,9 @@ class WebTauTestCliConfig {
 
     private Map commandLineArgsAsMap() {
         commandLine.options.collectEntries { [it.longOpt, it.value] }
+    }
+
+    interface ExitHandler {
+        void exit(int status)
     }
 }

--- a/webtau-groovy/src/test/groovy/com/twosigma/webtau/cli/WebTauTestCliConfigTest.groovy
+++ b/webtau-groovy/src/test/groovy/com/twosigma/webtau/cli/WebTauTestCliConfigTest.groovy
@@ -28,7 +28,7 @@ class WebTauTestCliConfigTest {
 
     @Test
     void "should use default environment values when evn is not specified"() {
-        def cliConfig = new WebTauTestCliConfig("--config=src/test/resources/test.cfg")
+        def cliConfig = new WebTauTestCliConfig("--config=src/test/resources/test.cfg", "testFile")
         cliConfig.parseConfig(groovy)
 
         cfg.baseUrl.should == "http://localhost:8180"
@@ -36,9 +36,17 @@ class WebTauTestCliConfigTest {
 
     @Test
     void "should use environment specific values when evn is specified"() {
-        def cliConfig = new WebTauTestCliConfig("--config=src/test/resources/test.cfg", "--env=dev")
+        def cliConfig = new WebTauTestCliConfig("--config=src/test/resources/test.cfg", "--env=dev", "testFile")
         cliConfig.parseConfig(groovy)
 
         cfg.baseUrl.should == "http://dev.host:8080"
+    }
+
+    @Test
+    void "should exit if only config file provided"() {
+        Integer retCode
+        new WebTauTestCliConfig({ retCode = it }, "--config=src/test/resources/test.cfg", "--env=dev")
+
+        retCode.should == 1
     }
 }


### PR DESCRIPTION
I believe there is a bug in how exit and help/usage printing is triggered.

Calling `webtau` correctly triggers this, as does `webtau --help`.  However, `webtau --config=test.cfg` (or any other valid config option but without a list of test scripts) does not.  Not providing test scripts results in it doing nothing other than some setup work so I would argue it's an error from the user and therefore help/usage should be printed.