### PR TITLE
capture http call related errors

### DIFF
--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/StepReporter.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/StepReporter.java
@@ -16,8 +16,8 @@
 
 package com.twosigma.webtau.reporter;
 
-public interface StepReporter<C> {
-    void onStepStart(TestStep<C> step);
-    void onStepSuccess(TestStep<C> step);
-    void onStepFailure(TestStep<C> step);
+public interface StepReporter<C, R> {
+    void onStepStart(TestStep<C, R> step);
+    void onStepSuccess(TestStep<C, R> step);
+    void onStepFailure(TestStep<C, R> step);
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/StepsTestResultPayloadExtractor.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/StepsTestResultPayloadExtractor.java
@@ -24,7 +24,7 @@ import static java.util.stream.Collectors.toList;
 
 public class StepsTestResultPayloadExtractor implements TestResultPayloadExtractor {
     @Override
-    public Stream<TestResultPayload> extract(Stream<TestStep<?>> testSteps) {
+    public Stream<TestResultPayload> extract(Stream<TestStep<?, ?>> testSteps) {
         List<? extends Map<String, ?>> stepsAsMaps = testSteps.map(TestStep::toMap).collect(toList());
 
         return Stream.of(new TestResultPayload("steps", stepsAsMaps));

--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/TestResultPayloadExtractor.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/TestResultPayloadExtractor.java
@@ -26,5 +26,5 @@ public interface TestResultPayloadExtractor {
      * @param testSteps test steps belonging to a single test
      * @return summarized test result payloads
      */
-    Stream<TestResultPayload> extract(Stream<TestStep<?>> testSteps);
+    Stream<TestResultPayload> extract(Stream<TestStep<?, ?>> testSteps);
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/TestResultPayloadExtractors.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/TestResultPayloadExtractors.java
@@ -27,8 +27,8 @@ public class TestResultPayloadExtractors {
     private static final Set<TestResultPayloadExtractor> extractors =
             ServiceLoaderUtils.load(TestResultPayloadExtractor.class);
 
-    public static Stream<TestResultPayload> extract(Stream<TestStep<?>> testSteps) {
-        List<TestStep<?>> steps = testSteps.collect(Collectors.toList());
+    public static Stream<TestResultPayload> extract(Stream<TestStep<?, ?>> testSteps) {
+        List<TestStep<?, ?>> steps = testSteps.collect(Collectors.toList());
         return extractors.stream().flatMap(e -> e.extract(steps.stream()));
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/ValueMatcherExpectationSteps.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/ValueMatcherExpectationSteps.java
@@ -19,8 +19,6 @@ package com.twosigma.webtau.reporter;
 import com.twosigma.webtau.expectation.ValueMatcher;
 import com.twosigma.webtau.expectation.timer.ExpectationTimer;
 
-import java.util.function.Supplier;
-
 import static com.twosigma.webtau.Ddjt.actual;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.TO;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.action;
@@ -31,13 +29,13 @@ public class ValueMatcherExpectationSteps {
     public static <C, V> void shouldStep(C context, V value, StepReportOptions stepReportOptions, TokenizedMessage valueDescription, ValueMatcher valueMatcher) {
         executeStep(context, value, valueDescription, valueMatcher, false,
                 tokenizedMessage(action("expecting")),
-                runnable(() -> actual(value).should(valueMatcher)), stepReportOptions);
+                () -> actual(value).should(valueMatcher), stepReportOptions);
     }
 
     public static <C, V> void shouldNotStep(C context, V value, StepReportOptions stepReportOptions, TokenizedMessage valueDescription, ValueMatcher valueMatcher) {
         executeStep(context, value, valueDescription, valueMatcher, true,
                 tokenizedMessage(action("expecting")),
-                runnable(() -> actual(value).shouldNot(valueMatcher)), stepReportOptions);
+                () -> actual(value).shouldNot(valueMatcher), stepReportOptions);
     }
 
     public static <C, V> void waitStep(C context, V value, StepReportOptions stepReportOptions,
@@ -45,7 +43,7 @@ public class ValueMatcherExpectationSteps {
                                        ExpectationTimer expectationTimer, long tickMillis, long timeOutMillis) {
         executeStep(context, value, valueDescription, valueMatcher, false,
                 tokenizedMessage(action("waiting"), TO),
-                runnable(() -> actual(value).waitTo(valueMatcher, expectationTimer, tickMillis, timeOutMillis)), stepReportOptions);
+                () -> actual(value).waitTo(valueMatcher, expectationTimer, tickMillis, timeOutMillis), stepReportOptions);
     }
 
     public static <C, V> void waitNotStep(C context, V value, StepReportOptions stepReportOptions,
@@ -53,15 +51,15 @@ public class ValueMatcherExpectationSteps {
                                           ExpectationTimer expectationTimer, long tickMillis, long timeOutMillis) {
         executeStep(context, value, valueDescription, valueMatcher, true,
                 tokenizedMessage(action("waiting"), TO),
-                runnable(() -> actual(value).waitToNot(valueMatcher, expectationTimer, tickMillis, timeOutMillis)),
+                () -> actual(value).waitToNot(valueMatcher, expectationTimer, tickMillis, timeOutMillis),
                 stepReportOptions);
     }
 
     private static <C, V> void executeStep(C context, V value, TokenizedMessage elementDescription,
                                            ValueMatcher valueMatcher, boolean isNegative,
-                                           TokenizedMessage messageStart, Supplier expectationValidation,
+                                           TokenizedMessage messageStart, Runnable expectationValidation,
                                            StepReportOptions stepReportOptions) {
-        TestStep<C> step = TestStep.create(context,
+        TestStep<C, Void> step = TestStep.create(context,
                 messageStart.add(elementDescription)
                         .add(matcher(isNegative ? valueMatcher.negativeMatchingMessage() : valueMatcher.matchingMessage())),
                 () -> tokenizedMessage(elementDescription)
@@ -71,12 +69,5 @@ public class ValueMatcherExpectationSteps {
                 expectationValidation);
 
         step.execute(stepReportOptions);
-    }
-
-    private static Supplier runnable(Runnable r) {
-        return () -> {
-            r.run();
-            return null;
-        };
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/ValueMatcherExpectationSteps.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/ValueMatcherExpectationSteps.java
@@ -19,6 +19,8 @@ package com.twosigma.webtau.reporter;
 import com.twosigma.webtau.expectation.ValueMatcher;
 import com.twosigma.webtau.expectation.timer.ExpectationTimer;
 
+import java.util.function.Supplier;
+
 import static com.twosigma.webtau.Ddjt.actual;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.TO;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.action;
@@ -29,13 +31,13 @@ public class ValueMatcherExpectationSteps {
     public static <C, V> void shouldStep(C context, V value, StepReportOptions stepReportOptions, TokenizedMessage valueDescription, ValueMatcher valueMatcher) {
         executeStep(context, value, valueDescription, valueMatcher, false,
                 tokenizedMessage(action("expecting")),
-                () -> actual(value).should(valueMatcher), stepReportOptions);
+                runnable(() -> actual(value).should(valueMatcher)), stepReportOptions);
     }
 
     public static <C, V> void shouldNotStep(C context, V value, StepReportOptions stepReportOptions, TokenizedMessage valueDescription, ValueMatcher valueMatcher) {
         executeStep(context, value, valueDescription, valueMatcher, true,
                 tokenizedMessage(action("expecting")),
-                () -> actual(value).shouldNot(valueMatcher), stepReportOptions);
+                runnable(() -> actual(value).shouldNot(valueMatcher)), stepReportOptions);
     }
 
     public static <C, V> void waitStep(C context, V value, StepReportOptions stepReportOptions,
@@ -43,7 +45,7 @@ public class ValueMatcherExpectationSteps {
                                        ExpectationTimer expectationTimer, long tickMillis, long timeOutMillis) {
         executeStep(context, value, valueDescription, valueMatcher, false,
                 tokenizedMessage(action("waiting"), TO),
-                () -> actual(value).waitTo(valueMatcher, expectationTimer, tickMillis, timeOutMillis), stepReportOptions);
+                runnable(() -> actual(value).waitTo(valueMatcher, expectationTimer, tickMillis, timeOutMillis)), stepReportOptions);
     }
 
     public static <C, V> void waitNotStep(C context, V value, StepReportOptions stepReportOptions,
@@ -51,12 +53,13 @@ public class ValueMatcherExpectationSteps {
                                           ExpectationTimer expectationTimer, long tickMillis, long timeOutMillis) {
         executeStep(context, value, valueDescription, valueMatcher, true,
                 tokenizedMessage(action("waiting"), TO),
-                () -> actual(value).waitToNot(valueMatcher, expectationTimer, tickMillis, timeOutMillis), stepReportOptions);
+                runnable(() -> actual(value).waitToNot(valueMatcher, expectationTimer, tickMillis, timeOutMillis)),
+                stepReportOptions);
     }
 
     private static <C, V> void executeStep(C context, V value, TokenizedMessage elementDescription,
                                            ValueMatcher valueMatcher, boolean isNegative,
-                                           TokenizedMessage messageStart, Runnable expectationValidation,
+                                           TokenizedMessage messageStart, Supplier expectationValidation,
                                            StepReportOptions stepReportOptions) {
         TestStep<C> step = TestStep.create(context,
                 messageStart.add(elementDescription)
@@ -68,5 +71,12 @@ public class ValueMatcherExpectationSteps {
                 expectationValidation);
 
         step.execute(stepReportOptions);
+    }
+
+    private static Supplier runnable(Runnable r) {
+        return () -> {
+            r.run();
+            return null;
+        };
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/stacktrace/StackTraceUtils.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/stacktrace/StackTraceUtils.java
@@ -113,11 +113,9 @@ public class StackTraceUtils {
         String stackTrace = renderStackTrace(t);
         List<String> lines = Arrays.asList(stackTrace.split("\n"));
 
-        return lines.get(0) + "\n" +
-                lines.subList(1, lines.size())
-                        .stream()
-                        .filter(filter)
-                        .collect(Collectors.joining("\n"));
+        return lines.stream()
+                .filter(filter)
+                .collect(Collectors.joining("\n")).trim();
     }
 
     private static boolean isStandardCall(String stackTraceLine) {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/reporter/TestStepTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/reporter/TestStepTest.groovy
@@ -19,6 +19,8 @@ package com.twosigma.webtau.reporter
 import org.junit.BeforeClass
 import org.junit.Test
 
+import java.util.function.Supplier
+
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.action
 import static com.twosigma.webtau.reporter.StepReportOptions.REPORT_ALL
 import static com.twosigma.webtau.reporter.TokenizedMessage.tokenizedMessage
@@ -59,6 +61,14 @@ class TestStepTest {
     }
 
     @Test
+    void "step should be able to return a value"() {
+        def step = createStep('supplier step', { return 2 + 2 })
+        def stepResult = step.execute(REPORT_ALL)
+
+        assert stepResult == 4
+    }
+
+    @Test
     void "should recursively return all the payloads from test step and nested test steps"() {
         def payloads = rootStep.getCombinedPayloads().collect(toList())
         assert payloads*.toMap() == [[id: 'id1'], [name: 'name1'], [id: 'id2'], [name: 'name2'], [id: 'id3'], [name: 'name3']]
@@ -80,7 +90,7 @@ class TestStepTest {
         assert ! rootStep.hasPayload(PayloadC)
     }
 
-    private static TestStep createStep(String title, Closure stepCode = {}) {
+    private static TestStep createStep(String title, Supplier stepCode = { return null }) {
         TestStep.create(null, tokenizedMessage(action(title)), {
             tokenizedMessage(action('done ' + title))
         }, stepCode)

--- a/webtau-reactjs/src/report/Report.js
+++ b/webtau-reactjs/src/report/Report.js
@@ -151,16 +151,24 @@ function enrichHttpCallsData(test, httpCalls) {
 function buildHttpCallsSummary(httpCalls) {
     return {
         total: httpCalls.length,
-        passed: httpCalls.filter(c => c.status === StatusEnum.PASSED).length,
-        failed: httpCalls.filter(c => c.status === StatusEnum.FAILED).length,
+        passed: count(StatusEnum.PASSED),
+        failed: count(StatusEnum.FAILED),
         skipped: 0,
-        errored: 0
+        errored: count(StatusEnum.ERRORED)
+    }
+
+    function count(status) {
+        return httpCalls.filter(c => c.status === status).length
     }
 }
 
 function deriveHttpCallStatus(httpCall) {
     if (httpCall.mismatches.length > 0) {
         return StatusEnum.FAILED
+    }
+
+    if (httpCall.errorMessage) {
+        return StatusEnum.ERRORED
     }
 
     return StatusEnum.PASSED

--- a/webtau-reactjs/src/report/WebTauReport.css
+++ b/webtau-reactjs/src/report/WebTauReport.css
@@ -24,6 +24,7 @@
     --webtau-source-code-background-color: #fff;
     --webtau-card-border-color: rgba(91, 91, 91, 0.12);
     --webtau-card-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    --webtau-monospace-font: CentSchbook Mono BT, Bitstream Vera Sans Mono, monofont, monospace;
 }
 
 body {

--- a/webtau-reactjs/src/report/details/Steps.css
+++ b/webtau-reactjs/src/report/details/Steps.css
@@ -46,7 +46,7 @@
 
 .step-token.error {
     color: #b02f08;
-    font-family: CentSchbook Mono BT, Bitstream Vera Sans Mono, monofont, monospace;
+    font-family: var(--webtau-monospace-font);
     white-space: pre;
 }
 

--- a/webtau-reactjs/src/report/details/http/HttpCallDetails.css
+++ b/webtau-reactjs/src/report/details/http/HttpCallDetails.css
@@ -36,8 +36,15 @@
 .http-call-details-url-test-name,
 .http-call-details-mismatches,
 .http-call-details-request-details,
-.http-call-details-response-details {
+.http-call-details-response-details,
+.http-call-details-error-message {
     padding: 15px;
+}
+
+.http-call-details-mismatches,
+.http-call-details-error-message {
+    font-family: var(--webtau-monospace-font);
+    white-space: pre;
 }
 
 .http-call-details-url {

--- a/webtau-reactjs/src/report/details/http/HttpCallDetails.js
+++ b/webtau-reactjs/src/report/details/http/HttpCallDetails.js
@@ -24,10 +24,6 @@ import './HttpCallDetails.css'
 import CardLabelAndNumber from '../../widgets/CardLabelAndNumber'
 
 function HttpCallDetails({httpCall, onTestSelect}) {
-    const mismatches = httpCall.mismatches.map((m, idx) => <div key={idx} className="mismatch">
-        <pre>{m}</pre>
-    </div>)
-
     return (
         <div className="http-call-details">
             <div className="http-call-latency-and-name">
@@ -36,17 +32,42 @@ function HttpCallDetails({httpCall, onTestSelect}) {
                 <UrlAndTestNameCard httpCall={httpCall} onTestSelect={onTestSelect}/>
             </div>
 
-            {mismatches.length > 0 &&
-            <Card className="http-call-details-mismatches">
-                {mismatches}
-            </Card>
-            }
+            <Mismatches httpCall={httpCall}/>
+            <ErrorMessage httpCall={httpCall}/>
 
             <div className="request-response">
                 <Request httpCall={httpCall}/>
                 <Response httpCall={httpCall}/>
             </div>
         </div>
+    )
+}
+
+function Mismatches({httpCall}) {
+    if (httpCall.mismatches.length === 0) {
+        return null
+    }
+
+    const mismatches = httpCall.mismatches.map((m, idx) => <div key={idx} className="mismatch">
+        <pre>{m}</pre>
+    </div>)
+
+    return (
+        <Card className="http-call-details-mismatches">
+            {mismatches}
+        </Card>
+    )
+}
+
+function ErrorMessage({httpCall}) {
+    if (!httpCall.errorMessage) {
+        return null
+    }
+
+    return (
+        <Card className="http-call-details-error-message">
+            {httpCall.errorMessage}
+        </Card>
     )
 }
 

--- a/webtau-reactjs/src/report/details/http/TestHttpCalls.css
+++ b/webtau-reactjs/src/report/details/http/TestHttpCalls.css
@@ -73,7 +73,7 @@
     margin-bottom: 20px;
 }
 
-.test-http-call.with-mismatches {
+.test-http-call.with-problem {
     background-color: rgba(239, 94, 99, 0.08);
 }
 

--- a/webtau-reactjs/src/report/details/http/TestHttpCalls.js
+++ b/webtau-reactjs/src/report/details/http/TestHttpCalls.js
@@ -60,7 +60,8 @@ class TestHttpCalls extends Component {
     }
 
     renderRow(httpCall, idx) {
-        const className = 'test-http-call' + (httpCall.mismatches.length > 0 ? ' with-mismatches' : '')
+        const hasProblem = httpCall.mismatches.length > 0 || !!httpCall.errorMessage
+        const className = 'test-http-call' + (hasProblem ? ' with-problem' : '')
         const isExpanded = this.isExpanded(idx)
 
         return (
@@ -100,10 +101,6 @@ class TestHttpCalls extends Component {
 }
 
 function HttpCallDetails({httpCall}) {
-    const mismatches = httpCall.mismatches.map((m, idx) => <div key={idx} className="mismatch">
-        <pre>{m}</pre>
-    </div>)
-
     return (
         <tr className="test-http-call-details">
             <td/>
@@ -111,13 +108,33 @@ function HttpCallDetails({httpCall}) {
             <td/>
             <td/>
             <td>
-                {mismatches}
+                <Mismatches httpCall={httpCall}/>
+                <ErrorMessage httpCall={httpCall}/>
+
                 <div className="request-response">
                     <Request httpCall={httpCall}/>
                     <Response httpCall={httpCall}/>
                 </div>
             </td>
         </tr>
+    )
+}
+
+function Mismatches({httpCall}) {
+    return httpCall.mismatches.map((m, idx) => <div key={idx} className="mismatch">
+        <pre>{m}</pre>
+    </div>)
+}
+
+function ErrorMessage({httpCall}) {
+    if (! httpCall.errorMessage) {
+        return null
+    }
+
+    return (
+        <div className="error-message">
+            <pre>{httpCall.errorMessage}</pre>
+        </div>
     )
 }
 

--- a/webtau-report/src/main/java/com/twosigma/webtau/report/ReportTestEntry.java
+++ b/webtau-report/src/main/java/com/twosigma/webtau/report/ReportTestEntry.java
@@ -46,7 +46,7 @@ public class ReportTestEntry {
     private Throwable exception;
 
     private List<TestResultPayload> payloads;
-    private List<TestStep<?>> steps;
+    private List<TestStep<?, ?>> steps;
 
     private boolean isRan;
     private Path workingDir;
@@ -137,11 +137,11 @@ public class ReportTestEntry {
         return payloads;
     }
 
-    public List<TestStep<?>> getSteps() {
+    public List<TestStep<?, ?>> getSteps() {
         return steps;
     }
 
-    public void addStep(TestStep<?> step) {
+    public void addStep(TestStep<?, ?> step) {
         steps.add(step);
     }
 
@@ -149,7 +149,7 @@ public class ReportTestEntry {
         payloads.add(testResultPayload);
     }
 
-    public void setSteps(List<TestStep<?>> steps) {
+    public void setSteps(List<TestStep<?, ?>> steps) {
         this.steps = steps;
     }
 

--- a/webtau-rest-groovy/src/test/groovy/com/twosigma/webtau/http/HttpTest.groovy
+++ b/webtau-rest-groovy/src/test/groovy/com/twosigma/webtau/http/HttpTest.groovy
@@ -31,7 +31,7 @@ import static com.twosigma.webtau.Ddjt.code
 import static com.twosigma.webtau.Ddjt.throwException
 import static com.twosigma.webtau.http.Http.http
 
-class HttpExtensionsTest {
+class HttpTest {
     static TestServer testServer = new TestServer()
 
     @BeforeClass
@@ -218,5 +218,16 @@ class HttpExtensionsTest {
         } should throwException(~/body\.a:/)
 
         http.lastValidationResult.mismatches.should == [~/body\.a:/]
+    }
+
+    @Test
+    void "captures failed http call"() {
+        code {
+            http.get('mailto://demo', [a: 1, b: 'text']) {
+            }
+        } should throwException(HttpException, ~/error during http\.get/)
+
+        http.lastValidationResult.errorMessage.should == 'java.lang.ClassCastException: ' +
+            'sun.net.www.protocol.mailto.MailToURLConnection cannot be cast to java.net.HttpURLConnection'
     }
 }

--- a/webtau-rest/src/main/java/com/twosigma/webtau/http/HttpCallsTestResultPayloadExtractor.java
+++ b/webtau-rest/src/main/java/com/twosigma/webtau/http/HttpCallsTestResultPayloadExtractor.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 
 public class HttpCallsTestResultPayloadExtractor implements TestResultPayloadExtractor {
     @Override
-    public Stream<TestResultPayload> extract(Stream<TestStep<?>> testSteps) {
+    public Stream<TestResultPayload> extract(Stream<TestStep<?, ?>> testSteps) {
         Stream<HttpValidationResult> payloads = testSteps
                 .flatMap(s -> s.getCombinedPayloadsOfType(HttpValidationResult.class));
 

--- a/webtau-rest/src/main/java/com/twosigma/webtau/http/HttpException.java
+++ b/webtau-rest/src/main/java/com/twosigma/webtau/http/HttpException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.http;
+
+class HttpException extends RuntimeException {
+    HttpException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/webtau-rest/src/test/groovy/com/twosigma/webtau/http/HttpValidationResultTest.groovy
+++ b/webtau-rest/src/test/groovy/com/twosigma/webtau/http/HttpValidationResultTest.groovy
@@ -34,13 +34,16 @@ class HttpValidationResultTest {
         n.get('childA').get().updateCheckLevel(CheckLevel.FuzzyFailed)
         n.get('childB').get().updateCheckLevel(CheckLevel.ExplicitPassed)
 
-        def validationResult = new HttpValidationResult('POST', '/test/url', 'http://site/test/url', null,
-                new HttpResponse(content: responseAsJson, contentType: 'application/json', statusCode: 200),
-                new HeaderDataNode(), n, 100)
+        def validationResult = new HttpValidationResult('POST', 'http://site/test/url', null)
+        validationResult.setResponse(new HttpResponse(content: responseAsJson, contentType: 'application/json', statusCode: 200))
+        validationResult.setElapsedTime(100)
+        validationResult.setResponseHeaderNode(new HeaderDataNode())
+        validationResult.setResponseBodyNode(n)
 
         validationResult.toMap().should equal([method: 'POST', url: 'http://site/test/url', responseType: 'application/json',
                                                responseBody: responseAsJson,
                                                mismatches: [],
+                                               errorMessage: null,
                                                responseStatusCode: 200,
                                                elapsedTime: 100,
                                                responseBodyChecks: [failedPaths: ['root.childA'], passedPaths:['root.childB']]])

--- a/webtau-rest/src/test/groovy/com/twosigma/webtau/http/OpenAPISpecValidatorTest.groovy
+++ b/webtau-rest/src/test/groovy/com/twosigma/webtau/http/OpenAPISpecValidatorTest.groovy
@@ -68,6 +68,6 @@ class OpenAPISpecValidatorTest {
     }
 
     static HttpValidationResult emptyResult() {
-        return new HttpValidationResult(null, null, null, null, null, null, null, 0)
+        return new HttpValidationResult(null, null, null)
     }
 }

--- a/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/StandaloneTest.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/StandaloneTest.groovy
@@ -70,7 +70,7 @@ class StandaloneTest implements StepReporter {
         return reportTestEntry.isFailed()
     }
 
-    List<TestStep<?>> getSteps() {
+    List<TestStep<?, ?>> getSteps() {
         return reportTestEntry.steps
     }
 

--- a/webtau/src/main/java/com/twosigma/webtau/WebTauDsl.java
+++ b/webtau/src/main/java/com/twosigma/webtau/WebTauDsl.java
@@ -17,25 +17,26 @@
 package com.twosigma.webtau;
 
 import com.twosigma.webtau.cfg.WebTauConfig;
-import com.twosigma.webtau.expectation.ValueMatcher;
-import com.twosigma.webtau.http.Http;
-import com.twosigma.webtau.http.HttpUrl;
-import com.twosigma.webtau.reporter.StepReportOptions;
-import com.twosigma.webtau.reporter.TestStep;
-import com.twosigma.webtau.reporter.TokenizedMessage;
 import com.twosigma.webtau.documentation.DocumentationDsl;
 import com.twosigma.webtau.driver.CurrentWebDriver;
+import com.twosigma.webtau.expectation.ValueMatcher;
 import com.twosigma.webtau.expectation.VisibleValueMatcher;
+import com.twosigma.webtau.http.Http;
+import com.twosigma.webtau.http.HttpUrl;
 import com.twosigma.webtau.page.Cookies;
 import com.twosigma.webtau.page.PageElement;
 import com.twosigma.webtau.page.path.ElementPath;
 import com.twosigma.webtau.page.path.GenericPageElement;
+import com.twosigma.webtau.reporter.StepReportOptions;
+import com.twosigma.webtau.reporter.TestStep;
+import com.twosigma.webtau.reporter.TokenizedMessage;
 import org.openqa.selenium.OutputType;
 
 import java.util.function.Supplier;
 
+import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.action;
+import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.urlValue;
 import static com.twosigma.webtau.reporter.TokenizedMessage.tokenizedMessage;
-import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.*;
 
 public class WebTauDsl extends Ddjt {
     public static final CurrentWebDriver driver = new CurrentWebDriver();
@@ -43,15 +44,11 @@ public class WebTauDsl extends Ddjt {
     public static final DocumentationDsl doc = new DocumentationDsl(driver);
     public static final Cookies cookies = new Cookies(driver);
 
-    public static <E> void executeStep(E context,
+    public static <C> void executeStep(C context,
                                        TokenizedMessage inProgressMessage,
                                        Supplier<TokenizedMessage> completionMessageSupplier,
                                        Runnable action) {
-        TestStep<E> step = TestStep.create(context, inProgressMessage, completionMessageSupplier, () -> {
-            action.run();
-            return null;
-        });
-
+        TestStep<C, Void> step = TestStep.create(context, inProgressMessage, completionMessageSupplier, action);
         step.execute(StepReportOptions.REPORT_ALL);
     }
 

--- a/webtau/src/main/java/com/twosigma/webtau/WebTauDsl.java
+++ b/webtau/src/main/java/com/twosigma/webtau/WebTauDsl.java
@@ -34,7 +34,6 @@ import org.openqa.selenium.OutputType;
 
 import java.util.function.Supplier;
 
-import static com.twosigma.webtau.cfg.WebTauConfig.getCfg;
 import static com.twosigma.webtau.reporter.TokenizedMessage.tokenizedMessage;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.*;
 
@@ -48,7 +47,11 @@ public class WebTauDsl extends Ddjt {
                                        TokenizedMessage inProgressMessage,
                                        Supplier<TokenizedMessage> completionMessageSupplier,
                                        Runnable action) {
-        TestStep<E> step = TestStep.create(context, inProgressMessage, completionMessageSupplier, action);
+        TestStep<E> step = TestStep.create(context, inProgressMessage, completionMessageSupplier, () -> {
+            action.run();
+            return null;
+        });
+
         step.execute(StepReportOptions.REPORT_ALL);
     }
 

--- a/webtau/src/main/java/com/twosigma/webtau/reporter/ScreenshotStepReporter.java
+++ b/webtau/src/main/java/com/twosigma/webtau/reporter/ScreenshotStepReporter.java
@@ -20,17 +20,17 @@ import com.twosigma.webtau.WebTauDsl;
 import com.twosigma.webtau.page.PageElement;
 import com.twosigma.webtau.report.ScreenshotStepPayload;
 
-public class ScreenshotStepReporter implements StepReporter<PageElement> {
+public class ScreenshotStepReporter implements StepReporter<PageElement, Void> {
     @Override
-    public void onStepStart(TestStep<PageElement> step) {
+    public void onStepStart(TestStep<PageElement, Void> step) {
     }
 
     @Override
-    public void onStepSuccess(TestStep<PageElement> step) {
+    public void onStepSuccess(TestStep<PageElement, Void> step) {
     }
 
     @Override
-    public void onStepFailure(TestStep<PageElement> step) {
+    public void onStepFailure(TestStep<PageElement, Void> step) {
         if (! WebTauDsl.wasBrowserUsed()) {
             return;
         }

--- a/webtau/src/main/java/com/twosigma/webtau/reporter/ScreenshotTestResultPayloadExtractor.java
+++ b/webtau/src/main/java/com/twosigma/webtau/reporter/ScreenshotTestResultPayloadExtractor.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 
 public class ScreenshotTestResultPayloadExtractor implements TestResultPayloadExtractor {
     @Override
-    public Stream<TestResultPayload> extract(Stream<TestStep<?>> testSteps) {
+    public Stream<TestResultPayload> extract(Stream<TestStep<?, ?>> testSteps) {
         Stream<ScreenshotStepPayload> payloads = testSteps
                 .flatMap(s -> s.getCombinedPayloadsOfType(ScreenshotStepPayload.class));
 


### PR DESCRIPTION
Report is now able to show/distinct http calls with error (e.g. wrong url protocol).
TestStep refactoring. 