### PR TITLE
get() method on lazy test resource

### DIFF
--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/data/LazyTestResource.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/data/LazyTestResource.groovy
@@ -29,12 +29,14 @@ class LazyTestResource<E> {
     }
 
     def getProperty(String name) {
-        synchronized (this) {
-            if (this.@originalCache == null) {
-                this.@originalCache = this.@originalSupplier.get()
-            }
+        return get()."$name"
+    }
 
-            return this.@originalCache."$name"
+    synchronized E get() {
+        if (this.@originalCache == null) {
+            this.@originalCache = this.@originalSupplier.get()
         }
+
+        return this.@originalCache
     }
 }


### PR DESCRIPTION
This will allow access to the entire contained object, not just individual properties.