### PR TITLE
print failed and errored tests at the end

### DIFF
--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/CliReportGenerator.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/CliReportGenerator.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli
+
+import com.twosigma.webtau.console.ConsoleOutputs
+import com.twosigma.webtau.console.ansi.Color
+import com.twosigma.webtau.report.Report
+import com.twosigma.webtau.report.ReportGenerator
+import com.twosigma.webtau.report.ReportTestEntry
+import com.twosigma.webtau.reporter.TestStatus
+import com.twosigma.webtau.reporter.stacktrace.StackTraceUtils
+
+class CliReportGenerator implements ReportGenerator {
+    @Override
+    void generate(Report report) {
+        printTestsWithStatus(report, TestStatus.Errored)
+        printTestsWithStatus(report, TestStatus.Failed)
+        printTotals(report)
+    }
+
+    private static void printTestsWithStatus(Report report, TestStatus status) {
+        if (report.testEntries.countWithStatus(status) == 0) {
+            return
+        }
+
+        ConsoleOutputs.out(Color.BLUE, status.toString() + ' tests:')
+        report.testEntries
+                .withStatus(status)
+                .each { te -> printFailedTest(te) }
+    }
+
+    private static void printFailedTest(ReportTestEntry testEntry) {
+        ConsoleOutputs.out(Color.RED, '[x] ', testEntry.scenario, Color.PURPLE, ' ',
+                testEntry.filePath)
+
+        ConsoleOutputs.out(StackTraceUtils.renderStackTraceWithoutLibCalls(testEntry.exception), '\n')
+    }
+
+    private static void printTotals(Report report) {
+        def summary = report.createSummary()
+
+        ConsoleOutputs.out('Total: ', summary.getTotal(), ', ',
+                Color.GREEN, ' Passed: ', summary.passed, ', ',
+                Color.YELLOW, ' Skipped: ', summary.skipped, ', ',
+                Color.RED, ' Failed: ', summary.failed, ', ',
+                ' Errored: ', summary.errored)
+
+    }
+}

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
@@ -26,6 +26,7 @@ import com.twosigma.webtau.console.ConsoleOutputs
 import com.twosigma.webtau.console.ansi.AnsiConsoleOutput
 import com.twosigma.webtau.driver.WebDriverCreator
 import com.twosigma.webtau.report.Report
+import com.twosigma.webtau.report.ReportGenerator
 import com.twosigma.webtau.report.ReportGenerators
 import com.twosigma.webtau.reporter.ConsoleStepReporter
 import com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder
@@ -44,7 +45,7 @@ import java.nio.file.Paths
 
 import static com.twosigma.webtau.cfg.WebTauConfig.getCfg
 
-class WebTauCliApp implements StandaloneTestListener {
+class WebTauCliApp implements StandaloneTestListener, ReportGenerator {
     private static StandardConsoleTestListener consoleTestReporter = new StandardConsoleTestListener()
     private static StepReporter stepReporter = new ConsoleStepReporter(IntegrationTestsMessageBuilder.converter)
     private static ScreenshotStepReporter screenshotStepReporter = new ScreenshotStepReporter()
@@ -83,6 +84,7 @@ class WebTauCliApp implements StandaloneTestListener {
             StepReporters.add(screenshotStepReporter)
 
             cfg.print()
+            ConsoleOutputs.out()
 
             testFiles().forEach {
                 runner.process(it, this)
@@ -138,6 +140,11 @@ class WebTauCliApp implements StandaloneTestListener {
         report.stopTimer()
 
         ReportGenerators.generate(report)
-        problemCount = consoleTestReporter.failed + consoleTestReporter.errored + consoleTestReporter.skipped
+    }
+
+    @Override
+    void generate(Report report) {
+        def summary = report.createSummary()
+        problemCount = (int) (summary.failed + summary.errored + summary.skipped)
     }
 }

--- a/webtau-groovy/src/main/resources/META-INF/services/com.twosigma.webtau.report.ReportGenerator
+++ b/webtau-groovy/src/main/resources/META-INF/services/com.twosigma.webtau.report.ReportGenerator
@@ -1,0 +1,17 @@
+#
+# Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.twosigma.webtau.cli.CliReportGenerator

--- a/webtau-groovy/src/test/groovy/com/twosigma/webtau/WebtauFeaturesTesting.groovy
+++ b/webtau-groovy/src/test/groovy/com/twosigma/webtau/WebtauFeaturesTesting.groovy
@@ -16,6 +16,7 @@
 
 package com.twosigma.webtau
 
+import com.twosigma.webtau.cli.WebTauCliApp
 import com.twosigma.webtau.console.ConsoleOutputs
 import com.twosigma.webtau.console.ansi.Color
 import com.twosigma.webtau.driver.WebDriverCreator
@@ -25,7 +26,6 @@ import com.twosigma.webtau.reporter.TestStep
 import com.twosigma.webtau.runner.standalone.StandaloneTest
 import com.twosigma.webtau.runner.standalone.StandaloneTestListener
 import com.twosigma.webtau.runner.standalone.StandaloneTestListeners
-import com.twosigma.webtau.cli.WebTauCliApp
 import com.twosigma.webtau.utils.FileUtils
 import com.twosigma.webtau.utils.JsonUtils
 import com.twosigma.webtau.utils.ResourceUtils
@@ -216,7 +216,7 @@ class WebtauFeaturesTesting implements StepReporter, StandaloneTestListener {
 
     @Override
     void afterTestRun(StandaloneTest test) {
-        testDescription = test.description
+        testDescription = test.scenario
     }
 
     @Override

--- a/webtau-report/src/main/java/com/twosigma/webtau/report/ReportTestEntries.java
+++ b/webtau-report/src/main/java/com/twosigma/webtau/report/ReportTestEntries.java
@@ -56,7 +56,11 @@ public class ReportTestEntries {
         return entries.isEmpty();
     }
 
+    public Stream<ReportTestEntry> withStatus(TestStatus status) {
+        return entries.stream().filter(e -> e.getTestStatus() == status);
+    }
+
     public long countWithStatus(TestStatus status) {
-        return entries.stream().filter(e -> e.getTestStatus() == status).count();
+        return withStatus(status).count();
     }
 }

--- a/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/StandaloneTest.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/StandaloneTest.groovy
@@ -54,7 +54,7 @@ class StandaloneTest implements StepReporter {
         return reportTestEntry.filePath
     }
 
-    String getDescription() {
+    String getScenario() {
         return reportTestEntry.scenario
     }
 

--- a/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/report/StandardConsoleTestListener.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/report/StandardConsoleTestListener.groovy
@@ -18,72 +18,28 @@ package com.twosigma.webtau.runner.standalone.report
 
 import com.twosigma.webtau.console.ConsoleOutputs
 import com.twosigma.webtau.console.ansi.Color
-import com.twosigma.webtau.reporter.stacktrace.StackTraceUtils
 import com.twosigma.webtau.runner.standalone.StandaloneTest
 import com.twosigma.webtau.runner.standalone.StandaloneTestListenerAdapter
 
 class StandardConsoleTestListener extends StandaloneTestListenerAdapter {
-    private int passed
-    private int failed
-    private int errored
-    private int skipped
-
     @Override
     void beforeTestRun(StandaloneTest test) {
-        ConsoleOutputs.out(Color.GREEN, test.description.trim())
-        ConsoleOutputs.out(Color.PURPLE, test.filePath, "\n")
+        ConsoleOutputs.out(Color.BLUE, test.scenario.trim(), ' ', Color.PURPLE, '(' + test.filePath + ')')
     }
 
     @Override
     void afterTestRun(StandaloneTest test) {
+        def scenario = test.scenario.trim()
         if (test.isFailed()) {
-            ConsoleOutputs.out(Color.RED, "[x] ", Color.BLUE, "failed")
-            displayStackTrace(test.exception)
-            failed++
+            ConsoleOutputs.out(Color.RED, "[x] ", Color.BLUE, scenario)
         } else if (test.hasError()) {
-            ConsoleOutputs.out(Color.RED, "[~] ", Color.BLUE, "error")
-            displayStackTrace(test.exception)
-            errored++
+            ConsoleOutputs.out(Color.RED, "[~] ", Color.BLUE, scenario)
         } else if (test.isSkipped()) {
-            ConsoleOutputs.out(Color.YELLOW, "[o] ", Color.BLUE, "skipped")
-            skipped++
+            ConsoleOutputs.out(Color.YELLOW, "[o] ", Color.BLUE, scenario)
         } else {
-            ConsoleOutputs.out(Color.GREEN, "[.] ", Color.BLUE, "passed")
-            passed++
+            ConsoleOutputs.out(Color.GREEN, "[.] ", Color.BLUE, scenario)
         }
-    }
 
-    int getTotal() {
-        return passed + failed + errored + skipped
-    }
-
-    int getPassed() {
-        return passed
-    }
-
-    int getFailed() {
-        return failed
-    }
-
-    int getErrored() {
-        return errored
-    }
-
-    int getSkipped() {
-        return skipped
-    }
-
-    @Override
-    void afterAllTests() {
         ConsoleOutputs.out()
-        ConsoleOutputs.out("Total: ", getTotal(), ", ",
-                Color.GREEN, " Passed: ", passed, ", ",
-                Color.YELLOW, " Skipped: ", skipped, ", ",
-                Color.RED, " Failed: ", failed, ", ",
-                " Errored: ", errored)
-    }
-
-    private static void displayStackTrace(Throwable t) {
-        ConsoleOutputs.out(StackTraceUtils.renderStackTraceWithoutLibCalls(t), "\n\n")
     }
 }

--- a/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
+++ b/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
@@ -25,9 +25,9 @@ class StandaloneTestRunnerTest {
 
     @Test
     void "should register tests with scenario keyword"() {
-        runner.tests.description.should == ['# first header\noptionally split into multiple lines and has a header\n',
-                                            '# second header\noptionally split into multiple lines and has a header\n',
-                                            '# third header\noptionally split into multiple lines and has a header\n']
+        runner.tests.scenario.should == ['# first header\noptionally split into multiple lines and has a header\n',
+                                         '# second header\noptionally split into multiple lines and has a header\n',
+                                         '# third header\noptionally split into multiple lines and has a header\n']
     }
 
     @Test


### PR DESCRIPTION
stop printing stacktraces for each test during test run
and instead printing failed stacktraces at the end