### PR TITLE
replace groovyJavaStubs with groovydoc. add implicit groovy profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,51 @@
 
     <profiles>
         <profile>
+            <id>groovy-auto-activated</id>
+            <activation>
+                <file>
+                    <exists>src/main/groovy</exists>
+                </file>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-sources</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>addSources</goal>
+                                    <goal>addTestSources</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>compile</id>
+                                <goals>
+                                    <goal>compile</goal>
+                                    <goal>testCompile</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>groovy-docs</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>groovydoc</goal>
+                                </goals>
+                                <configuration>
+                                    <groovydocOutputDirectory>${project.build.directory}/apidocs</groovydocOutputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/webtau-core-groovy/pom.xml
+++ b/webtau-core-groovy/pom.xml
@@ -59,24 +59,4 @@
             <type>test-jar</type>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>compile</goal>
-                            <goal>generateStubs</goal>
-                            <goal>addTestSources</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/webtau-groovy-ast/pom.xml
+++ b/webtau-groovy-ast/pom.xml
@@ -38,24 +38,4 @@
             <artifactId>groovy-all</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>compile</goal>
-                            <goal>generateStubs</goal>
-                            <goal>addTestSources</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/webtau-groovy/pom.xml
+++ b/webtau-groovy/pom.xml
@@ -81,24 +81,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>compile</goal>
-                            <goal>generateStubs</goal>
-                            <goal>addTestSources</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/webtau-http-groovy/pom.xml
+++ b/webtau-http-groovy/pom.xml
@@ -62,24 +62,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>compile</goal>
-                            <goal>generateStubs</goal>
-                            <goal>addTestSources</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/webtau-standalone-runner-groovy/pom.xml
+++ b/webtau-standalone-runner-groovy/pom.xml
@@ -55,24 +55,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>addSources</goal>
-                            <goal>compile</goal>
-                            <goal>generateStubs</goal>
-                            <goal>addTestSources</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
Stubs generation is messing IDEA. They were generated to generate javadocs for maven central. 
Instead we generate docs using gmaven-plus:groovydoc and point to a location that java expects.