### PR TITLE
Maven plugin to respect skipTests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <module>webtau-docs</module>
         <module>webtau-maven-plugin</module>
         <module>webtau-maven-plugin-test</module>
+        <module>webtau-maven-plugin-test-skip</module>
         <module>webtau-dist</module>
         <module>webtau</module>
     </modules>

--- a/webtau-maven-plugin-test-skip/pom.xml
+++ b/webtau-maven-plugin-test-skip/pom.xml
@@ -24,7 +24,7 @@
         <version>0.30-SNAPSHOT</version>
     </parent>
 
-    <artifactId>webtau-maven-plugin-test</artifactId>
+    <artifactId>webtau-maven-plugin-test-skip</artifactId>
 
     <dependencies>
         <dependency>
@@ -49,6 +49,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <skipTests>true</skipTests>
                     <workingDir>${project.basedir}/src/tests/groovy</workingDir>
                     <tests>
                         <directory>${project.basedir}/src/tests/groovy</directory>

--- a/webtau-maven-plugin-test-skip/src/tests/groovy/scenarios/featureA.groovy
+++ b/webtau-maven-plugin-test-skip/src/tests/groovy/scenarios/featureA.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scenarios
+
+import static com.twosigma.webtau.WebTauGroovyDsl.scenario
+
+scenario('test should fail') {
+    2.should == 3
+}

--- a/webtau-maven-plugin-test-skip/src/tests/groovy/webtau.cfg
+++ b/webtau-maven-plugin-test-skip/src/tests/groovy/webtau.cfg
@@ -1,0 +1,1 @@
+url = 'http://localhost:8080'

--- a/webtau-maven-plugin/src/main/groovy/com/twosigma/webtau/maven/WebTauMavenRunner.groovy
+++ b/webtau-maven-plugin/src/main/groovy/com/twosigma/webtau/maven/WebTauMavenRunner.groovy
@@ -50,20 +50,24 @@ class WebTauMavenRunner extends AbstractMojo {
         if (skipTests()) {
             getLog().info("Skipping webtau tests")
         } else {
-            def fileSetManager = new FileSetManager()
-            def files = fileSetManager.getIncludedFiles(tests) as List
+            runTests()
+        }
+    }
 
-            getLog().info("test files:\n    " + files.join("\n    "))
+    private void runTests() {
+        def fileSetManager = new FileSetManager()
+        def files = fileSetManager.getIncludedFiles(tests) as List
 
-            def args = buildArgs([env: env, url: url, workingDir: workingDir])
-            args.addAll(files)
+        getLog().info("test files:\n    " + files.join("\n    "))
 
-            def cli = new WebTauCliApp(args as String[])
-            cli.start(true)
+        def args = buildArgs([env: env, url: url, workingDir: workingDir])
+        args.addAll(files)
 
-            if (cli.problemCount > 0) {
-                throw new MojoFailureException("check failed tests")
-            }
+        def cli = new WebTauCliApp(args as String[])
+        cli.start(true)
+
+        if (cli.problemCount > 0) {
+            throw new MojoFailureException("check failed tests")
         }
     }
 
@@ -73,7 +77,7 @@ class WebTauMavenRunner extends AbstractMojo {
                 .collect { e -> "--${e.key}=${e.value}"}
     }
 
-    boolean skipTests() {
+    private boolean skipTests() {
         return skipTests || skip
     }
 }

--- a/webtau-open-api/src/main/java/com/twosigma/webtau/openapi/OpenApiSpecConfig.java
+++ b/webtau-open-api/src/main/java/com/twosigma/webtau/openapi/OpenApiSpecConfig.java
@@ -26,12 +26,16 @@ import static com.twosigma.webtau.cfg.WebTauConfig.getCfg;
 
 public class OpenApiSpecConfig implements WebTauConfigHandler {
     static final ConfigValue specUrl = declare("openApiSpecUrl",
-            "url of OpenAPI 2 spec against which to validate http calls", () -> "");
+            "url of OpenAPI 2 spec against which to validate http calls", () -> null);
 
     static final ConfigValue ignoreAdditionalProperties = declare("openApiIgnoreAdditionalProperties",
             "ignore additional OpenAPI properties ", () -> false);
 
     public static String specFullPath() {
+        if (specUrl.getAsString().isEmpty()) {
+            return "";
+        }
+
         return getCfg().getWorkingDir()
                 .resolve(specUrl.getAsString())
                 .toString();

--- a/webtau-open-api/src/main/java/com/twosigma/webtau/openapi/OpenApiSpecConfig.java
+++ b/webtau-open-api/src/main/java/com/twosigma/webtau/openapi/OpenApiSpecConfig.java
@@ -26,7 +26,7 @@ import static com.twosigma.webtau.cfg.WebTauConfig.getCfg;
 
 public class OpenApiSpecConfig implements WebTauConfigHandler {
     static final ConfigValue specUrl = declare("openApiSpecUrl",
-            "url of OpenAPI 2 spec against which to validate http calls", () -> null);
+            "url of OpenAPI 2 spec against which to validate http calls", () -> "");
 
     static final ConfigValue ignoreAdditionalProperties = declare("openApiIgnoreAdditionalProperties",
             "ignore additional OpenAPI properties ", () -> false);


### PR DESCRIPTION
This is based on the surefire plugin behaviour: http://maven.apache.org/plugins-archives/maven-surefire-plugin-2.12.4/examples/skipping-test.html and code: https://github.com/apache/maven-surefire/blob/7149edc6f24fa8bff06372e24a177e86d4960d8c/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java#L177

It started off as just adding the skip tests capability and a test for it but found a couple of issues I had to fix:
1. the maven plugin test was not actually executing the tests because it requires the execution part to be set up.  I think there is a way to make that work by default but I don't remember off the top of my head what that is
1. adding a fix for the above unearthed a bug in the OpenAPISpec loading which resulted in an exception being thrown if no spec was configured in the config file.  This is because we resolved working dir with `cfg.spec.asString()` (pseudocode).  This by default returns `""` and therefore the spec was the working dir which then threw an exception