### PR TITLE
break long http header key in report. use monospace for key

### DIFF
--- a/webtau-reactjs/src/report/details/http-header/HttpHeader.css
+++ b/webtau-reactjs/src/report/details/http-header/HttpHeader.css
@@ -16,13 +16,15 @@
 
 .http-header {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: minmax(auto, 3fr) 5fr;
     grid-gap: 5px 20px;
 
     margin-top: 10px;
 }
 
 .http-header-key {
+    font-family: var(--webtau-monospace-font);
+    word-break: break-word;
 }
 
 .collapsed-http-header,

--- a/webtau-reactjs/src/report/details/http-header/HttpHeader.js
+++ b/webtau-reactjs/src/report/details/http-header/HttpHeader.js
@@ -23,8 +23,8 @@ export default function HttpHeader({header}) {
         <div className="http-header">
             {header.map((entry, idx) => (
                 <React.Fragment key={idx}>
-                    <div className="http-header-key">{entry.key}</div>
-                    <div className="http-header-value">{entry.value}</div>
+                    <div className="http-header-key http-header-entry">{entry.key}</div>
+                    <div className="http-header-value http-header-entry">{entry.value}</div>
                 </React.Fragment>
             ))}
         </div>

--- a/webtau-reactjs/src/test-data/testData.js
+++ b/webtau-reactjs/src/test-data/testData.js
@@ -47,6 +47,23 @@ const report = {
                 "mismatches": [],
                 "responseType": "application/json;charset=UTF-8",
                 "responseStatusCode": 200,
+                "requestHeader" : [ ],
+                "responseHeader" : [ {
+                    "key" : "Transfer-Encoding-LongerKeyLongishSufixLongerKeyLongishSufixLongerKeyLongishSufix",
+                    "value" : "chunked"
+                }, {
+                    "key" : null,
+                    "value" : "HTTP/1.1 201"
+                }, {
+                    "key" : "Date",
+                    "value" : "Tue, 23 Oct 2018 11:01:26 GMT"
+                }, {
+                    "key" : "Content-Type",
+                    "value" : "application/json;charset=UTF-8"
+                }, {
+                    "key" : "Location",
+                    "value" : "http://localhost:8080/customers/1"
+                } ],
                 "responseBody": "{\n  \"id\" : 1,\n  \"firstName\" : \"FN\",\n  \"lastName\" : \"LN\",\n  \"_links\" : {\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/customers/1\"\n    },\n    \"customer\" : {\n      \"href\" : \"http://localhost:8080/customers/1\"\n    }\n  }\n}",
                 "responseBodyChecks": {
                     "failedPaths": [],


### PR DESCRIPTION
closes #154 