### PR TITLE
Produce accurate expected messages for comparisons other than equality

### DIFF
--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/groovy/ast/ShouldAstTransformationTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/groovy/ast/ShouldAstTransformationTest.groovy
@@ -38,7 +38,7 @@ class ShouldAstTransformationTest extends GroovyTestCase {
             'mismatches:\n' +
             '\n' +
             '[value]:   actual: 2 <java.lang.Integer>\n' +
-            '         expected: 2 <java.lang.Integer>')
+            '         expected: not 2 <java.lang.Integer>')
     }
 
     void testShouldTransformationOnNull() {
@@ -77,7 +77,7 @@ class ShouldAstTransformationTest extends GroovyTestCase {
             'mismatches:\n' +
             '\n' +
             '[value]:   actual: 2 <java.lang.Integer>\n' +
-            '         expected: 2 <java.lang.Integer>')
+            '         expected: not 2 <java.lang.Integer>')
 
     }
 

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/AnyCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/AnyCompareToHandler.java
@@ -21,7 +21,6 @@ import com.twosigma.webtau.expectation.equality.CompareToComparator;
 import com.twosigma.webtau.expectation.equality.CompareToHandler;
 
 import static com.twosigma.webtau.expectation.equality.handlers.HandlerMessages.renderActualExpected;
-import static com.twosigma.webtau.utils.TraceUtils.renderValueAndType;
 
 public class AnyCompareToHandler implements CompareToHandler {
     @Override
@@ -37,7 +36,8 @@ public class AnyCompareToHandler implements CompareToHandler {
     @Override
     public void compareEqualOnly(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
         boolean isEqual = actual.equals(expected);
-        comparator.reportEqualOrNotEqual(this, isEqual, actualPath, renderActualExpected(actual, expected));
+        String message = renderActualExpected(comparator.getAssertionMode(), actual, expected);
+        comparator.reportEqualOrNotEqual(this, isEqual, actualPath, message);
     }
 
     @Override
@@ -46,7 +46,7 @@ public class AnyCompareToHandler implements CompareToHandler {
         Comparable<Object> actualComparable = (Comparable<Object>) actual;
         int compareTo = actualComparable.compareTo(expected);
 
-        String message = renderActualExpected(actual, expected);
+        String message = renderActualExpected(comparator.getAssertionMode(), actual, expected);
         comparator.reportCompareToValue(this, compareTo, actualPath, message);
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/DateAndStringCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/DateAndStringCompareToHandler.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static com.twosigma.webtau.expectation.equality.handlers.HandlerMessages.expected;
 import static com.twosigma.webtau.utils.TraceUtils.renderValueAndType;
 
 public class DateAndStringCompareToHandler implements CompareToHandler {
@@ -140,13 +141,13 @@ public class DateAndStringCompareToHandler implements CompareToHandler {
 
         private String renderActualExpected(Object actual, Object expected) {
             return "  actual: " + renderValueAndType(actual) + "\n" +
-                    "expected: " + renderValueAndType(expected);
+                    expected(compareToComparator.getAssertionMode(), renderValueAndType(expected));
         }
 
         private String renderActualExpectedWithNormalized(ZonedDateTime actual, ZonedDateTime expected,
                                                           ZonedDateTime normalizedActual, ZonedDateTime normalizedExpected) {
             return "  actual: " + renderValueAndType(actual) + "(UTC normalized: " + normalizedActual + ")\n" +
-                    "expected: " + renderValueAndType(expected) + "(UTC normalized: " + normalizedExpected + ")";
+                    expected(compareToComparator.getAssertionMode(), renderValueAndType(expected) + "(UTC normalized: " + normalizedExpected + ")");
         }
     }
 

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/HandlerMessages.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/HandlerMessages.java
@@ -16,22 +16,55 @@
 
 package com.twosigma.webtau.expectation.equality.handlers;
 
+import com.twosigma.webtau.expectation.equality.CompareToComparator;
+
 import static com.twosigma.webtau.utils.TraceUtils.renderValueAndType;
 
 class HandlerMessages {
     private static final String ACTUAL_PREFIX = "  actual: ";
     private static final String EXPECTED_PREFIX = "expected: ";
 
-    static String renderActualExpected(Object actual, Object expected) {
+    static String renderActualExpected(CompareToComparator.AssertionMode assertionMode, Object actual, Object expected) {
         return ACTUAL_PREFIX + renderValueAndType(actual) + "\n" +
-                EXPECTED_PREFIX + renderValueAndType(expected);
+                expected(assertionMode, renderValueAndType(expected));
     }
 
-    static String renderActualExpected(Object convertedActual, Object convertedExpected,
+    static String renderActualExpected(CompareToComparator.AssertionMode assertionMode,
+                                       Object convertedActual, Object convertedExpected,
                                        Object actual, Object expected) {
         return ACTUAL_PREFIX + renderValueAndType(convertedActual) +
                 "(before conversion: " + renderValueAndType(actual) + ")\n" +
-                EXPECTED_PREFIX + renderValueAndType(convertedExpected) +
-                "(before conversion: " + renderValueAndType(expected) + ")";
+                expected(assertionMode, renderValueAndType(convertedExpected) +
+                "(before conversion: " + renderValueAndType(expected) + ")");
+    }
+
+    static String expected(CompareToComparator.AssertionMode assertionMode, Object expected) {
+        return expected(EXPECTED_PREFIX, assertionMode, expected);
+    }
+
+    static String expected(String prefix, CompareToComparator.AssertionMode assertionMode, Object expected) {
+        String expectedMsg = prefix;
+
+        switch (assertionMode) {
+            case NOT_EQUAL:
+                expectedMsg += "not ";
+                break;
+            case GREATER_THAN:
+                expectedMsg += "> ";
+                break;
+            case GREATER_THAN_OR_EQUAL:
+                expectedMsg += ">= ";
+                break;
+            case LESS_THAN:
+                expectedMsg += "< ";
+                break;
+            case LESS_THAN_OR_EQUAL:
+                expectedMsg += "<= ";
+                break;
+        }
+
+        expectedMsg += expected;
+        expectedMsg += "\n";
+        return expectedMsg;
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/LiveValueCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/LiveValueCompareToHandler.java
@@ -30,6 +30,6 @@ public class LiveValueCompareToHandler implements CompareToHandler {
     @Override
     public void compareEqualOnly(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
         LiveValue actualLiveValue = (LiveValue) actual;
-        comparator.compareIsEqual(actualPath, actualLiveValue.get(), expected);
+        comparator.compareUsingEqualOnly(actualPath, actualLiveValue.get(), expected);
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/MapAndBeanCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/MapAndBeanCompareToHandler.java
@@ -39,11 +39,7 @@ public class MapAndBeanCompareToHandler implements CompareToHandler {
     }
 
     private boolean isBean(Object o) {
-        if (o instanceof Iterable || o instanceof Map) {
-            return false;
-        }
-
-        return true;
+        return !(o instanceof Iterable || o instanceof Map);
     }
 
     @Override
@@ -55,10 +51,10 @@ public class MapAndBeanCompareToHandler implements CompareToHandler {
         expectedMap.keySet().forEach(p -> {
             ActualPath propertyPath = actualPath.property(p);
 
-            if (! actualAsMap.containsKey(p)) {
-                comparator.reportMissing(this, propertyPath, expectedMap.get(p));
-            } else {
+            if (actualAsMap.containsKey(p)) {
                 comparator.compareUsingEqualOnly(propertyPath, actualAsMap.get(p), expectedMap.get(p));
+            } else {
+                comparator.reportMissing(this, propertyPath, expectedMap.get(p));
             }
         });
     }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NullCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NullCompareToHandler.java
@@ -20,6 +20,7 @@ import com.twosigma.webtau.expectation.ActualPath;
 import com.twosigma.webtau.expectation.equality.CompareToComparator;
 import com.twosigma.webtau.expectation.equality.CompareToHandler;
 
+import static com.twosigma.webtau.expectation.equality.handlers.HandlerMessages.expected;
 import static com.twosigma.webtau.utils.TraceUtils.renderValueAndType;
 
 public class NullCompareToHandler implements CompareToHandler {
@@ -37,16 +38,13 @@ public class NullCompareToHandler implements CompareToHandler {
     public void compareEqualOnly(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
         if (actual == null && expected == null) {
             comparator.reportEqual(this, actualPath,
-                    "  actual: null\n" +
-                            "expected: null");
+                    "  actual: null\n" + expected(comparator.getAssertionMode(), null));
         } else if (actual == null) {
             comparator.reportNotEqual(this, actualPath,
-                    "  actual: null\n" +
-                            "expected: " + renderValueAndType(expected));
+                    "  actual: null\n" + expected(comparator.getAssertionMode(), renderValueAndType(expected)));
         } else {
             comparator.reportNotEqual(this, actualPath,
-                    "  actual: " + renderValueAndType(actual) + "\n" +
-                            "expected: null\n");
+                    "  actual: " + renderValueAndType(actual) + "\n" + expected(comparator.getAssertionMode(), null));
         }
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NumberAndStringCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NumberAndStringCompareToHandler.java
@@ -41,7 +41,7 @@ public class NumberAndStringCompareToHandler implements CompareToHandler {
         Number actualNumber = convertToNumber(actual);
 
         if (actualNumber == null) {
-            comparator.reportEqualOrNotEqual(this, false, actualPath, renderActualExpected(Double.NaN, expected));
+            comparator.reportEqualOrNotEqual(this, false, actualPath, renderActualExpected(comparator.getAssertionMode(), Double.NaN, expected));
         } else {
             comparator.compareUsingEqualOnly(actualPath, actualNumber, expected);
         }
@@ -53,7 +53,7 @@ public class NumberAndStringCompareToHandler implements CompareToHandler {
 
         if (actualNumber == null) {
             comparator.reportCompareToValue(this, compareToValueToFail(comparator), actualPath,
-                    renderActualExpected(Double.NaN, expected));
+                    renderActualExpected(comparator.getAssertionMode(), Double.NaN, expected));
         } else {
             comparator.compareUsingCompareTo(actualPath, actualNumber, expected);
         }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NumbersCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NumbersCompareToHandler.java
@@ -38,7 +38,7 @@ public class NumbersCompareToHandler implements CompareToHandler {
 
     @Override
     public void compareEqualOnly(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
-        ConvertedAndOriginal convertedAndOriginal = new ConvertedAndOriginal(actual, expected);
+        ConvertedAndOriginal convertedAndOriginal = new ConvertedAndOriginal(comparator.getAssertionMode(), actual, expected);
 
         boolean isEqual = convertedAndOriginal.compareTo() == 0;
         comparator.reportEqualOrNotEqual(this, isEqual,
@@ -47,7 +47,7 @@ public class NumbersCompareToHandler implements CompareToHandler {
 
     @Override
     public void compareGreaterLessEqual(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
-        ConvertedAndOriginal convertedAndOriginal = new ConvertedAndOriginal(actual, expected);
+        ConvertedAndOriginal convertedAndOriginal = new ConvertedAndOriginal(comparator.getAssertionMode(), actual, expected);
 
         comparator.reportCompareToValue(this, convertedAndOriginal.compareTo(),
                 actualPath, convertedAndOriginal.renderActualExpected());
@@ -58,12 +58,14 @@ public class NumbersCompareToHandler implements CompareToHandler {
     }
 
     private static class ConvertedAndOriginal {
+        CompareToComparator.AssertionMode assertionMode;
         Object actual;
         Object expected;
         Comparable convertedActual;
         Comparable convertedExpected;
 
-        ConvertedAndOriginal(Object actual, Object expected) {
+        ConvertedAndOriginal(CompareToComparator.AssertionMode assertionMode, Object actual, Object expected) {
+            this.assertionMode = assertionMode;
             this.actual = actual;
             this.expected = expected;
 
@@ -78,7 +80,7 @@ public class NumbersCompareToHandler implements CompareToHandler {
         }
 
         String renderActualExpected() {
-            return HandlerMessages.renderActualExpected(convertedActual, convertedExpected, actual, expected);
+            return HandlerMessages.renderActualExpected(assertionMode, convertedActual, convertedExpected, actual, expected);
         }
 
         private static Class largest(Object actual, Object expected) {

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/RegexpEqualCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/RegexpEqualCompareToHandler.java
@@ -22,6 +22,8 @@ import com.twosigma.webtau.expectation.equality.CompareToHandler;
 
 import java.util.regex.Pattern;
 
+import static com.twosigma.webtau.expectation.equality.handlers.HandlerMessages.expected;
+
 public class RegexpEqualCompareToHandler implements CompareToHandler {
     @Override
     public boolean handleEquality(Object actual, Object expected) {
@@ -34,11 +36,11 @@ public class RegexpEqualCompareToHandler implements CompareToHandler {
 
         boolean isEqual = expectedPattern.matcher(actual.toString()).find();
         comparator.reportEqualOrNotEqual(this, isEqual,
-                actualPath, renderActualExpected(actual, expected));
+                actualPath, renderActualExpected(comparator.getAssertionMode(), actual, expected));
     }
 
-    private String renderActualExpected(Object actual, Object expected) {
+    private String renderActualExpected(CompareToComparator.AssertionMode assertionMode, Object actual, Object expected) {
         return "   actual string: " + actual.toString() + "\n" +
-               "expected pattern: " + expected.toString();
+               expected("expected pattern: ", assertionMode, expected.toString());
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/StringCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/StringCompareToHandler.java
@@ -20,6 +20,7 @@ import com.twosigma.webtau.expectation.ActualPath;
 import com.twosigma.webtau.expectation.equality.CompareToComparator;
 import com.twosigma.webtau.expectation.equality.CompareToHandler;
 
+import static com.twosigma.webtau.expectation.equality.handlers.HandlerMessages.expected;
 import static com.twosigma.webtau.utils.TraceUtils.renderValueAndType;
 
 public class StringCompareToHandler implements CompareToHandler {
@@ -36,16 +37,18 @@ public class StringCompareToHandler implements CompareToHandler {
 
         boolean isEqual = actualString.equals(expectedString);
         comparator.reportEqualOrNotEqual(this, isEqual,
-                actualPath, renderActualExpected(actual, actualString, expected, expectedString));
+                actualPath, renderActualExpected(comparator.getAssertionMode(), actual, actualString, expected, expectedString));
     }
 
     private String convertToString(Object expected) {
         return expected.toString();
     }
 
-    private String renderActualExpected(Object actual, Object convertedActual, Object expected, Object convertedExpected) {
+    private String renderActualExpected(CompareToComparator.AssertionMode assertionMode,
+                                        Object actual, Object convertedActual,
+                                        Object expected, Object convertedExpected) {
         return "  actual: " + renderValueAndType(convertedActual) + additionalTypeInfo(actual, convertedActual) + "\n" +
-                "expected: " + renderValueAndType(convertedExpected) + additionalTypeInfo(expected, convertedExpected);
+                expected(assertionMode, renderValueAndType(convertedExpected) + additionalTypeInfo(expected, convertedExpected));
     }
 
     private String additionalTypeInfo(Object original, Object converted) {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/ActualExpectedTestReportExpectations.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/ActualExpectedTestReportExpectations.groovy
@@ -18,7 +18,12 @@ package com.twosigma.webtau.expectation.equality
 
 class ActualExpectedTestReportExpectations {
     static String simpleActualExpectedWithIntegers(int actual, int expected) {
+        return simpleActualExpectedWithIntegers(actual, null, expected)
+    }
+
+    static String simpleActualExpectedWithIntegers(int actual, String expectedPrefix, int expected) {
+        def prefix = expectedPrefix != null && !expectedPrefix.isEmpty() && !expectedPrefix.endsWith(" ") ? expectedPrefix + " " : ""
         return "value:   actual: $actual <java.lang.Integer>\n" +
-               "       expected: $expected <java.lang.Integer>"
+               "       expected: $prefix$expected <java.lang.Integer>"
     }
 }

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/EqualMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/EqualMatcherTest.groovy
@@ -51,7 +51,7 @@ class EqualMatcherTest {
         assert matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMatchedMessage(actualPath, actual) == "doesn't equal $expected\n" +
             "matches:\n\n" +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "not", expected)
     }
 
     @Test
@@ -60,7 +60,7 @@ class EqualMatcherTest {
         assert !matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMismatchedMessage(actualPath, actual) ==  "equals $expected, but shouldn't\n" +
             "mismatches:\n\n" +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "not", expected)
     }
 
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/GreaterThanMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/GreaterThanMatcherTest.groovy
@@ -33,7 +33,7 @@ class GreaterThanMatcherTest {
         assert matcher.matches(actualPath, actual)
         assert matcher.matchedMessage(actualPath, actual) == "greater than $expected\n" +
             'matches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, ">", expected)
 
     }
 
@@ -43,7 +43,7 @@ class GreaterThanMatcherTest {
         assert !matcher.matches(actualPath, actual)
         assert matcher.mismatchedMessage(actualPath, actual) ==  "less then or equal to $expected\n" +
             'mismatches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, ">", expected)
     }
 
     @Test
@@ -52,7 +52,7 @@ class GreaterThanMatcherTest {
         assert matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMatchedMessage(actualPath, actual) == "less than or equal to $expected\n" +
             'matches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "<=", expected)
     }
 
     @Test
@@ -61,7 +61,7 @@ class GreaterThanMatcherTest {
         assert !matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMismatchedMessage(actualPath, actual) ==  "value is greater than $expected, but should be less or equal to\n" +
             'mismatches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "<=", expected)
     }
 
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/GreaterThanOrEqualMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/GreaterThanOrEqualMatcherTest.groovy
@@ -40,7 +40,7 @@ class GreaterThanOrEqualMatcherTest {
         assert matcher.matches(actualPath, actual)
         assert matcher.matchedMessage(actualPath, actual) == "greater than or equal $expected\n" +
             'matches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, ">=", expected)
     }
 
     @Test
@@ -49,7 +49,7 @@ class GreaterThanOrEqualMatcherTest {
         assert !matcher.matches(actualPath, actual)
         assert matcher.mismatchedMessage(actualPath, actual) ==  "less then $expected\n" +
             'mismatches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, ">=", expected)
     }
 
     @Test
@@ -58,7 +58,7 @@ class GreaterThanOrEqualMatcherTest {
         assert matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMatchedMessage(actualPath, actual) == "less than $expected\n" +
             'matches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "<", expected)
     }
 
     @Test
@@ -75,7 +75,7 @@ class GreaterThanOrEqualMatcherTest {
         assert !matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMismatchedMessage(actualPath, actual) == "value is greater than or equal to $expected, but should be less\n" +
             'mismatches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "<", expected)
     }
 
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/LessThanMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/LessThanMatcherTest.groovy
@@ -33,7 +33,7 @@ class LessThanMatcherTest {
         assert matcher.matches(actualPath, actual)
         assert matcher.matchedMessage(actualPath, actual) == "less than $expected\n" +
             'matches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "<", expected)
 
     }
 
@@ -43,7 +43,7 @@ class LessThanMatcherTest {
         assert !matcher.matches(actualPath, actual)
         assert matcher.mismatchedMessage(actualPath, actual) ==  "greater then or equal to $expected\n" +
             'mismatches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "<", expected)
     }
 
     @Test
@@ -52,7 +52,7 @@ class LessThanMatcherTest {
         assert matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMatchedMessage(actualPath, actual) == "greater than or equal to $expected\n" +
             'matches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, ">=", expected)
     }
 
     @Test
@@ -61,7 +61,7 @@ class LessThanMatcherTest {
         assert !matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMismatchedMessage(actualPath, actual) ==  "value is less than $expected, but should be greater or equal to\n" +
             'mismatches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, ">=", expected)
     }
 
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/LessThanOrEqualMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/LessThanOrEqualMatcherTest.groovy
@@ -40,7 +40,7 @@ class LessThanOrEqualMatcherTest {
         assert matcher.matches(actualPath, actual)
         assert matcher.matchedMessage(actualPath, actual) == "less than or equal $expected\n" +
             'matches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "<=", expected)
     }
 
     @Test
@@ -49,7 +49,7 @@ class LessThanOrEqualMatcherTest {
         assert !matcher.matches(actualPath, actual)
         assert matcher.mismatchedMessage(actualPath, actual) ==  "greater then $expected\n" +
             'mismatches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "<=", expected)
     }
 
     @Test
@@ -58,7 +58,7 @@ class LessThanOrEqualMatcherTest {
         assert matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMatchedMessage(actualPath, actual) == "greater than $expected\n" +
             'matches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, ">", expected)
     }
 
     @Test
@@ -75,7 +75,7 @@ class LessThanOrEqualMatcherTest {
         assert !matcher.negativeMatches(actualPath, actual)
         assert matcher.negativeMismatchedMessage(actualPath, actual) == "value is less than or equal to $expected, but should be greater\n" +
             'mismatches:\n\n' +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, ">", expected)
     }
 
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/NotEqualMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/NotEqualMatcherTest.groovy
@@ -32,7 +32,7 @@ class NotEqualMatcherTest {
 
         assert matcher.matches(actualPath, actual)
         assert matcher.matchedMessage(actualPath, actual) == "doesn't equal $expected\n" +
-            'matches:\n\n' + simpleActualExpectedWithIntegers(actual, expected)
+            'matches:\n\n' + simpleActualExpectedWithIntegers(actual, "not", expected)
     }
 
     @Test
@@ -43,7 +43,7 @@ class NotEqualMatcherTest {
         assert matcher.mismatchedMessage(actualPath, actual) ==  "equals $expected, but shouldn't\n" +
             "mismatches:\n" +
             "\n" +
-            simpleActualExpectedWithIntegers(actual, expected)
+            simpleActualExpectedWithIntegers(actual, "not", expected)
     }
 
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/DateAndStringCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/DateAndStringCompareToHandlerTest.groovy
@@ -69,7 +69,7 @@ class DateAndStringCompareToHandlerTest {
             actual("2018-01-01T00:00:00Z").should(beGreaterThan(LocalDate.of(2018, 1, 1)))
         } should throwException("\nless then or equal to 2018-01-01\nmismatches:\n\n" +
             "[value]:   actual: 2018-01-01T00:00Z <java.time.ZonedDateTime>\n" +
-            "         expected: 2018-01-01 <java.time.LocalDate>")
+            "         expected: > 2018-01-01 <java.time.LocalDate>")
     }
 
     @Test
@@ -93,7 +93,7 @@ class DateAndStringCompareToHandlerTest {
             "mismatches:\n" +
             "\n" +
             "[value]:   actual: 2018-01-02T10:00+01:00 <java.time.ZonedDateTime>(UTC normalized: 2018-01-02T09:00Z[UTC])\n" +
-            "         expected: 2018-01-02T10:00Z[UTC] <java.time.ZonedDateTime>(UTC normalized: 2018-01-02T10:00Z[UTC])")
+            "         expected: > 2018-01-02T10:00Z[UTC] <java.time.ZonedDateTime>(UTC normalized: 2018-01-02T10:00Z[UTC])")
     }
 
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/HandlerMessagesTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/HandlerMessagesTest.groovy
@@ -1,0 +1,300 @@
+package com.twosigma.webtau.expectation.equality.handlers
+
+import com.twosigma.webtau.data.live.LiveValue
+import org.junit.Test
+
+import java.time.LocalDate
+import java.util.stream.Stream
+
+import static com.twosigma.webtau.Ddjt.actual
+import static com.twosigma.webtau.Ddjt.code
+import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.Ddjt.lessThan
+import static com.twosigma.webtau.Ddjt.throwException
+
+class HandlerMessagesTest {
+    // AnyCompareTo messages
+    @Test
+    void "equal objects"() {
+        code {
+            actual(new TestBean("foo")).should(equal(new TestBean("bar")))
+        } should throwException(AssertionError, ~/expected: bar/)
+    }
+
+    @Test
+    void "not equal objects"() {
+        code {
+            actual(new TestBean("foo")).shouldNot(equal(new TestBean("foo")))
+        } should throwException(AssertionError, ~/expected: not foo/)
+    }
+
+    @Test
+    void "not less than integers"() {
+        code {
+            actual(10).shouldNot(lessThan(20))
+        } should throwException(AssertionError, ~/expected: >= 20/)
+    }
+
+    @Test
+    void "less than integers"() {
+        code {
+            actual(10).should(lessThan(9))
+        } should throwException(AssertionError, ~/expected: < 9/)
+    }
+
+    // DateAndStringCompareTo messages
+    @Test
+    void "equal date and string"() {
+        code {
+            actual("2018-10-31").should(equal(LocalDate.of(2018, 11, 1)))
+        } should throwException(AssertionError, ~/expected: 2018-11-01/)
+    }
+
+    @Test
+    void "not equal date and string"() {
+        code {
+            actual("2018-10-31").shouldNot(equal(LocalDate.of(2018, 10, 31)))
+        } should throwException(AssertionError, ~/expected: not 2018-10-31/)
+    }
+
+    @Test
+    void "less than date and string"() {
+        code {
+            actual("2018-10-31").should(lessThan(LocalDate.of(2018, 10, 31)))
+        } should throwException(AssertionError, ~/expected: < 2018-10-31/)
+    }
+
+    // IterableCompareTo messages
+    @Test
+    void "equal iterables"() {
+        code {
+            actual(Arrays.asList(1)).should(equal(Arrays.asList(2)))
+        } should throwException(AssertionError, ~/expected: 2/)
+    }
+
+    @Test
+    void "not equal iterables"() {
+        code {
+            actual(Arrays.asList(1)).shouldNot(equal(Arrays.asList(1)))
+        } should throwException(AssertionError, ~/expected: not 1/)
+    }
+
+    // LiveValueCompareTo messages
+    @Test
+    void "equal live value"() {
+        code {
+            actual(new TestLiveValue(1)).should(equal(2))
+        } should throwException(AssertionError, ~/expected: 2/)
+    }
+
+    @Test
+    void "not equal live value"() {
+        code {
+            actual(new TestLiveValue(1)).shouldNot(equal(1))
+        } should throwException(AssertionError, ~/expected: not 1/)
+    }
+
+    // MapAndBeanCompareTo messages
+    @Test
+    void "equal map and bean"() {
+        def expected = [
+            prop: "b"
+        ]
+
+        code {
+            actual(new TestBean("a")).should(equal(expected))
+        } should throwException(AssertionError, ~/expected: "b"/)
+    }
+
+    @Test
+    void "not equal map and bean"() {
+        def expected = [
+            prop: "a"
+        ]
+
+        code {
+            actual(new TestBean("a")).shouldNot(equal(expected))
+        } should throwException(AssertionError, ~/expected: not "a"/)
+    }
+
+    // MapsCompareTo messages
+    @Test
+    void "equal maps"() {
+        def actualMap = [
+            a: 1
+        ]
+        def expected = [
+            a: 2
+        ]
+
+        code {
+            actual(actualMap).should(equal(expected))
+        } should throwException(AssertionError, ~/expected: 2/)
+    }
+
+    @Test
+    void "not equal maps"() {
+        def map = [
+            a: 1
+        ]
+
+        code {
+            actual(map).shouldNot(equal(map))
+        } should throwException(AssertionError, ~/expected: not 1/)
+    }
+
+    // NullCompareTo messages
+    @Test
+    void "equal null"() {
+        code {
+            actual(1).should(equal(null))
+        } should throwException(AssertionError, ~/expected: null/)
+    }
+
+    @Test
+    void "not equal null"() {
+        code {
+            actual(null).shouldNot(equal(null))
+        } should throwException(AssertionError, ~/expected: not null/)
+    }
+
+    // NumberAndStringCompareTo messages
+    @Test
+    void "equal number and string"() {
+        code {
+            actual("1").should(equal(2))
+        } should throwException(AssertionError, ~/expected: 2/)
+    }
+
+    @Test
+    void "not equal number and string"() {
+        code {
+            actual("1").shouldNot(equal(1))
+        } should throwException(AssertionError, ~/expected: not 1/)
+    }
+
+    @Test
+    void "less than number and string"() {
+        code {
+            actual("1").should(lessThan(0))
+        } should throwException(AssertionError, ~/expected: < 0/)
+    }
+
+    // NumbersCompareTo messages
+    @Test
+    void "equal numbers"() {
+        code {
+            actual(1).should(equal(2.0))
+        } should throwException(AssertionError, ~/expected: 2/)
+    }
+
+    @Test
+    void "not equal numbers"() {
+        code {
+            actual(1).shouldNot(equal(1.0))
+        } should throwException(AssertionError, ~/expected: not 1/)
+    }
+
+    @Test
+    void "less than numbers"() {
+        code {
+            actual(1).should(lessThan(0.0))
+        } should throwException(AssertionError, ~/expected: < 0/)
+    }
+
+    // RegexpEqualCompareTo messages
+    @Test
+    void "equal regexp"() {
+        code {
+            actual("foo").should(equal(~/bar/))
+        } should throwException(AssertionError, ~/expected pattern: bar/)
+    }
+
+    @Test
+    void "not equal regexp"() {
+        code {
+            actual("foo").shouldNot(equal(~/foo/))
+        } should throwException(AssertionError, ~/expected pattern: not foo/)
+    }
+
+    // StreamAndIterableCompareTo messages
+    @Test
+    void "equal stream and iterable"() {
+        code {
+            actual(Stream.of(1)).should(equal(Arrays.asList(2)))
+        } should throwException(AssertionError, ~/expected: 2/)
+    }
+
+    @Test
+    void "not equal stream and iterable"() {
+        code {
+            actual(Stream.of(1)).shouldNot(equal(Arrays.asList(1)))
+        } should throwException(AssertionError, ~/expected: not 1/)
+    }
+
+    // StringCompareTo messages
+    @Test
+    void "equal strings"() {
+        code {
+            actual("foo").should(equal("bar"))
+        } should throwException(AssertionError, ~/expected: "bar"/)
+    }
+
+    @Test
+    void "not equal strings"() {
+        code {
+            actual("foo").shouldNot(equal("foo"))
+        } should throwException(AssertionError, ~/expected: not "foo"/)
+    }
+
+    // Test classes
+    static class TestBean {
+        private final String prop
+
+        TestBean(String prop) {
+            this.prop = prop
+        }
+
+        String getProp() {
+            return prop
+        }
+
+        boolean equals(o) {
+            if (this.is(o)) return true
+            if (getClass() != o.class) return false
+
+            TestBean testBean = (TestBean) o
+
+            if (prop != testBean.prop) return false
+
+            return true
+        }
+
+        int hashCode() {
+            return (prop != null ? prop.hashCode() : 0)
+        }
+
+        @Override
+        String toString() {
+            return prop
+        }
+    }
+
+    private static class TestLiveValue implements LiveValue<Integer> {
+        private final Integer value
+
+        TestLiveValue(Integer value) {
+            this.value = value
+        }
+
+        @Override
+        Integer get() {
+            return value
+        }
+
+        @Override
+        String toString() {
+            return "TestLiveValue{" + value + '}'
+        }
+    }
+}

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NumbersCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NumbersCompareToHandlerTest.groovy
@@ -61,7 +61,7 @@ class NumbersCompareToHandlerTest {
         assertEquals(
             "mismatches:\n\n" +
             "value:   actual: 10.0 <java.math.BigDecimal>(before conversion: 10.0 <java.lang.Double>)\n" +
-            "       expected: 9 <java.math.BigDecimal>(before conversion: 9 <java.lang.Long>)",
+            "       expected: < 9 <java.math.BigDecimal>(before conversion: 9 <java.lang.Long>)",
             comparator.generateLessThanMismatchReport())
     }
 
@@ -94,7 +94,7 @@ class NumbersCompareToHandlerTest {
 
         code {
             actual(10.0).should(beGreaterThanOrEqual(11))
-        } should throwException(AssertionError, ~/expected: 11/)
+        } should throwException(AssertionError, ~/expected: >= 11/)
     }
 
     private static void assertHandlesTypes(handleMethodName) {

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -83,7 +83,7 @@ class HttpGroovyTest implements HttpConfiguration {
             'mismatches:\n' +
             '\n' +
             'body.a:   actual: null\n' +
-            '        expected: null')
+            '        expected: not null')
     }
 
     @Test

--- a/webtau-http/src/test/groovy/com/twosigma/webtau/http/datanode/DataNodeCompareToHandlerTest.groovy
+++ b/webtau-http/src/test/groovy/com/twosigma/webtau/http/datanode/DataNodeCompareToHandlerTest.groovy
@@ -82,6 +82,6 @@ class DataNodeCompareToHandlerTest {
         assertEquals('matches:\n' +
             '\n' +
             'node:   actual: {node={k1: v1, k2: v2}} <java.util.Collections.UnmodifiableMap>\n' +
-            '      expected: null', comparator.generateNotEqualMatchReport())
+            '      expected: not null', comparator.generateNotEqualMatchReport())
     }
 }


### PR DESCRIPTION
Currently, this test:
```groovy
scenario('should not be null assertion') {
    def value = null
    value.shouldNot == null
}
```

Results in this exception:
```
java.lang.AssertionError: 
equals [null], but shouldn't
mismatches:

[value]:   actual: null
         expected: null
```

The `expected: null` part is very confusing as we're in fact expecting it to be not null.  This PR fixes the rendering of the expected value for not equals, less than, etc.

I created a new test which exercises all the `CompareToHandler`s because some had their own rendering.  There are a few however that are missing:
* RecordAndMapCompareTo
* TableDataCompareTo
* TraceableValueCompareTo
* ValueMatcherCompareTo

I can add them in due course but I'll need to figure out exactly how to test them.