### PR TITLE
Fix test failure with Java 9

### DIFF
--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/HandlerMessagesTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/HandlerMessagesTest.groovy
@@ -221,14 +221,14 @@ class HandlerMessagesTest {
     @Test
     void "equal stream and iterable"() {
         code {
-            actual(Stream.of(1)).should(equal(Arrays.asList(2)))
+            actual(Arrays.asList(1).stream()).should(equal(Arrays.asList(2)))
         } should throwException(AssertionError, ~/expected: 2/)
     }
 
     @Test
     void "not equal stream and iterable"() {
         code {
-            actual(Stream.of(1)).shouldNot(equal(Arrays.asList(1)))
+            actual(Arrays.asList(1).stream()).shouldNot(equal(Arrays.asList(1)))
         } should throwException(AssertionError, ~/expected: not 1/)
     }
 


### PR DESCRIPTION
This is due to https://issues.apache.org/jira/browse/GROOVY-8338.  Instead of upgrading Groovy, I have made the code uglier but did create an issue to remember to upgrade: https://github.com/twosigma/webtau/issues/203