### PR TITLE
Verbose DSL scenario names

### DIFF
--- a/webtau-docs/webtau/groovy-specific-runner/selective-run.md
+++ b/webtau-docs/webtau/groovy-specific-runner/selective-run.md
@@ -1,9 +1,8 @@
 # sscenario
 
-Define tests with `sscenario` to only run those tests and skip all the other tests defined in all the test files.
+Define tests with `sscenario` or `singleScenario` to only run those tests and skip all the other tests defined in all the test files.
 Useful during tests creation or debugging.
 
-:include-file: scenarios/concept/runOnlySelected.groovy {title: "Selective tests run", highlight: "sscenario"}
+:include-file: scenarios/concept/runOnlySelected.groovy {title: "Selective tests run", highlight: ["sscenario", "singleScenario"]}
 
 Note: `webtau` command line will exit with non zero code if there are `sscenario` tests present
- 

--- a/webtau-docs/webtau/groovy-specific-runner/skipping-tests.md
+++ b/webtau-docs/webtau/groovy-specific-runner/skipping-tests.md
@@ -18,3 +18,10 @@ Consider creating your project specific shortcuts to avoid boilerplate.
 Here is an example of `onlyForEnv` shortcut definition.
 
 :include-groovy: com/twosigma/webtau/WebTauGroovyDsl.groovy {entry: "onlyForEnv", title: "Custom shortcut"}
+
+# Unconditionally Skipping Tests
+
+Instead of `scenario`, use `dscenario` or `disabledScenario` to always skip a test.  This is analogous to 
+Junit's `@Ignore` or `@Disabled`.
+
+:include-file: scenarios/concept/skipTests.groovy {title: "Disable tests"}

--- a/webtau-docs/webtau/toc
+++ b/webtau-docs/webtau/toc
@@ -31,7 +31,7 @@ groovy-specific-runner
     data-driven-scenarios
     tests-hard-stops
     selective-run
-    conditional-run
+    skipping-tests
 generic-runners
     JUnit-4
 configuration

--- a/webtau-feature-testing/examples/scenarios/concept/runOnlySelected.groovy
+++ b/webtau-feature-testing/examples/scenarios/concept/runOnlySelected.groovy
@@ -12,7 +12,11 @@ sscenario('step two') {
     // test that you want to focus on
 }
 
-scenario('step three') {
+singleScenario('step three') {
+    // test that you want to focus on
+}
+
+scenario('step four') {
     http.put('/extra') {
         // ...
     }

--- a/webtau-feature-testing/examples/scenarios/concept/skipTests.groovy
+++ b/webtau-feature-testing/examples/scenarios/concept/skipTests.groovy
@@ -1,0 +1,15 @@
+package scenarios.concept
+
+import static com.twosigma.webtau.WebTauGroovyDsl.*
+
+dscenario('do not execute this scenario') {
+    http.get('/new-endpoint') {
+        price.shouldBe > 0
+    }
+}
+
+disabledScenario('do not execute this scenario either') {
+    http.get('/new-endpoint') {
+        price.shouldBe > 0
+    }
+}

--- a/webtau-feature-testing/src/test/groovy/com/twosigma/webtau/featuretesting/WebTauConceptFeaturesTest.groovy
+++ b/webtau-feature-testing/src/test/groovy/com/twosigma/webtau/featuretesting/WebTauConceptFeaturesTest.groovy
@@ -61,6 +61,11 @@ class WebTauConceptFeaturesTest {
     }
 
     @Test
+    void "disable tests"() {
+        runCli('skipTests.groovy', 'webtau.cfg')
+    }
+
+    @Test
     void "conditional tests custom condition skip"() {
         runCli('conditionalCustomRegistrationSkip.groovy', 'webtau.cfg')
     }

--- a/webtau-feature-testing/test-expectations/scenarios/concept/runOnlySelected/run-details.json
+++ b/webtau-feature-testing/test-expectations/scenarios/concept/runOnlySelected/run-details.json
@@ -3,10 +3,13 @@
     "scenario" : "step one",
     "stepsSummary" : { }
   }, {
-    "scenario" : "step three",
+    "scenario" : "step four",
     "stepsSummary" : { }
   }, {
     "scenario" : "step two",
+    "stepsSummary" : { }
+  }, {
+    "scenario" : "step three",
     "stepsSummary" : { }
   } ],
   "exitCode" : 1

--- a/webtau-feature-testing/test-expectations/scenarios/concept/skipTests/run-details.json
+++ b/webtau-feature-testing/test-expectations/scenarios/concept/skipTests/run-details.json
@@ -1,0 +1,10 @@
+{
+  "scenarioDetails" : [ {
+    "scenario" : "do not execute this scenario",
+    "stepsSummary" : { }
+  }, {
+    "scenario" : "do not execute this scenario either",
+    "stepsSummary" : { }
+  } ],
+  "exitCode" : 0
+}

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/WebTauGroovyDsl.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/WebTauGroovyDsl.groovy
@@ -51,6 +51,10 @@ class WebTauGroovyDsl extends WebTauDsl {
         }
     }
 
+    static void singleScenario(String description, Closure code) {
+        sscenario(description, code)
+    }
+
     static void sscenario(String description, Closure code) {
         if (!testRunner) {
             runAdHoc(description, code)
@@ -59,11 +63,15 @@ class WebTauGroovyDsl extends WebTauDsl {
         }
     }
 
+    static void disabledScenario(String description, Closure code) {
+        dscenario(description, code)
+    }
+
     static void dscenario(String description, Closure code) {
         if (!testRunner) {
             ConsoleOutputs.out(Color.YELLOW, "disabled test ", Color.GREEN, FontStyle.BOLD, description)
         } else {
-            testRunner.scenario(description, code)
+            testRunner.dscenario(description, code)
         }
     }
 


### PR DESCRIPTION
A few changes in this PR:
- adding `singleScenario` and `disabledScenario` as aliases for `sscenario` and `dscenario` respectively.  This is to aid readability but still allow conciseness if desired
- adding `dscenario` to documentation.  I highjacked and renamed the selective skipping chapter for this.  Feel free to disagree with that move
- fixing a bug with `dscenario` and test runners where it would invoke the scenario anyway.  Should check what happens in interactive mode though because I think we should execute it if someone runs the disabled scenario explicitly but not if someone runs the entire file