### PR TITLE
Improve pattern rendering

### DIFF
--- a/webtau-core/src/main/java/com/twosigma/webtau/data/render/DataRenderers.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/render/DataRenderers.java
@@ -41,6 +41,7 @@ public class DataRenderers {
         renders.add(new ByteArrayRenderer());
         renders.add(new TableDataRenderer());
         renders.add(new StringRenderer());
+        renders.add(new PatternRenderer());
         renders.add(Objects::toString);
 
         return renders;

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/render/PatternRenderer.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/render/PatternRenderer.java
@@ -1,0 +1,12 @@
+package com.twosigma.webtau.data.render;
+
+import java.util.regex.Pattern;
+
+public class PatternRenderer implements DataRenderer {
+    @Override
+    public String render(Object data) {
+        return data instanceof Pattern ?
+                "pattern /" + data + "/" :
+                null;
+    }
+}

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/data/render/DataRenderersTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/data/render/DataRenderersTest.groovy
@@ -18,14 +18,25 @@ package com.twosigma.webtau.data.render
 
 import org.junit.Test
 
-class NullRendererTest {
+class DataRenderersTest {
     @Test
     void "null values should be rendered as a String"() {
         assert new NullRenderer().render(null) == "[null]"
+        assert DataRenderers.render(null) == "[null]"
     }
 
     @Test
-    void "should not handle non-null values"() {
+    void "null renderer should not handle non-null values"() {
         assert new NullRenderer().render("some object") == null
+    }
+
+    @Test
+    void "strings are rendered with quotes"() {
+        assert DataRenderers.render("some object") == "\"some object\""
+    }
+
+    @Test
+    void "regex are rendered as patterns"() {
+        assert DataRenderers.render(~/some stuff/) == "pattern /some stuff/"
     }
 }

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/WebTauGroovyDsl.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/WebTauGroovyDsl.groovy
@@ -93,7 +93,7 @@ class WebTauGroovyDsl extends WebTauDsl {
      *
      * <pre>
      * def lazySharedData = createLazyResource("resource name") {
-     *      def result = callToInitializeTheResouce()
+     *      def result = callToInitializeTheResource()
      *      return new MySharedData(firstName: result.firstName, score: result.score)
      * }
      * ...


### PR DESCRIPTION
The problem this PR is addressing is demonstrated by an assertion such as:
```groovy
http.get("someurl") {
    field.should == ~/a regex pattern/
}
```

This results in an error:
```
failed expecting field to equal a regex pattern
```

If the pattern does not use any actual regex (and is therefore used to approximate a contains test), it's not really obvious that it's a pattern or where the actual pattern starts and stops.  Contrast that with the equivalent error for a string which would be `failed expecting field to equal "a string"` and the actual actual/expected rendering:
```
field:      actual string: the actual value
         expected pattern: a regex pattern
```
This makes it clear that it's a pattern test.

This PR results in the error becoming:
```
failed expecting field to equal pattern /a regex pattern/
```