### PR TITLE
set compare to handler

### DIFF
--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/SetCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/SetCompareToHandler.java
@@ -57,17 +57,18 @@ public class SetCompareToHandler implements CompareToHandler {
         }
 
         void compare() {
-            expectedLeft.removeIf(this::checkActualAndRemoveIfMatch);
+            expectedLeft.removeIf(this::checkAndRemoveFromActualIfMatch);
 
             actualLeft.forEach(e -> comparator.reportExtra(SetCompareToHandler.this, actualPath, e));
             expectedLeft.forEach(e -> comparator.reportMissing(SetCompareToHandler.this, actualPath, e));
         }
 
-        private boolean checkActualAndRemoveIfMatch(Object expected) {
+        private boolean checkAndRemoveFromActualIfMatch(Object expected) {
             Iterator<?> it = actualLeft.iterator();
             int idx = 0;
             while (it.hasNext()) {
                 Object actual = it.next();
+
                 CompareToResult result = localComparator.compareUsingEqualOnly(actualPath, actual, expected);
                 if (result.isEqual()) {
                     comparator.reportEqual(SetCompareToHandler.this, actualPath.index(idx),

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/SetCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/SetCompareToHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.expectation.equality.handlers;
+
+import com.twosigma.webtau.expectation.ActualPath;
+import com.twosigma.webtau.expectation.equality.CompareToComparator;
+import com.twosigma.webtau.expectation.equality.CompareToHandler;
+import com.twosigma.webtau.expectation.equality.CompareToResult;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+public class SetCompareToHandler implements CompareToHandler {
+    @Override
+    public boolean handleEquality(Object actual, Object expected) {
+        return actual instanceof Set && expected instanceof Set;
+    }
+
+    @Override
+    public void compareEqualOnly(CompareToComparator compareToComparator, ActualPath actualPath, Object actual, Object expected) {
+        Set<?> actualSet = (Set) actual;
+        Set<?> expectedSet = (Set) expected;
+
+        Comparator comparator = new Comparator(compareToComparator, actualPath, actualSet, expectedSet);
+        comparator.compare();
+    }
+
+    private class Comparator {
+        private final CompareToComparator comparator;
+        private final CompareToComparator localComparator;
+        private final ActualPath actualPath;
+        List<?> actualLeft;
+        List<?> expectedLeft;
+
+        Comparator(CompareToComparator compareToComparator, ActualPath actualPath, Set<?> actual, Set<?> expected) {
+            this.comparator = compareToComparator;
+            this.localComparator = CompareToComparator.comparator(compareToComparator.getAssertionMode());
+            this.actualPath = actualPath;
+            this.actualLeft = new ArrayList<>(actual);
+            this.expectedLeft = new ArrayList<>(expected);
+        }
+
+        void compare() {
+            expectedLeft.removeIf(this::checkActualAndRemoveIfMatch);
+
+            actualLeft.forEach(e -> comparator.reportExtra(SetCompareToHandler.this, actualPath, e));
+            expectedLeft.forEach(e -> comparator.reportMissing(SetCompareToHandler.this, actualPath, e));
+        }
+
+        private boolean checkActualAndRemoveIfMatch(Object expected) {
+            Iterator<?> it = actualLeft.iterator();
+            int idx = 0;
+            while (it.hasNext()) {
+                Object actual = it.next();
+                CompareToResult result = localComparator.compareUsingEqualOnly(actualPath, actual, expected);
+                if (result.isEqual()) {
+                    comparator.reportEqual(SetCompareToHandler.this, actualPath.index(idx),
+                            HandlerMessages.renderActualExpected(comparator.getAssertionMode(), actual, expected));
+                    it.remove();
+                    return true;
+                }
+
+                idx++;
+            }
+
+            return false;
+        }
+    }
+}

--- a/webtau-core/src/main/resources/META-INF/services/com.twosigma.webtau.expectation.equality.CompareToHandler
+++ b/webtau-core/src/main/resources/META-INF/services/com.twosigma.webtau.expectation.equality.CompareToHandler
@@ -23,6 +23,7 @@ com.twosigma.webtau.expectation.equality.handlers.ByteArrayCompareToHandler
 com.twosigma.webtau.expectation.equality.handlers.TableDataCompareToHandler
 com.twosigma.webtau.expectation.equality.handlers.IterableAndTableDataCompareToHandler
 com.twosigma.webtau.expectation.equality.handlers.StreamAndIterableCompareToHandler
+com.twosigma.webtau.expectation.equality.handlers.SetCompareToHandler
 com.twosigma.webtau.expectation.equality.handlers.IterableCompareToHandler
 com.twosigma.webtau.expectation.equality.handlers.RecordAndMapCompareToHandler
 com.twosigma.webtau.expectation.equality.handlers.MapAndBeanCompareToHandler

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/IterableCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/IterableCompareToHandlerTest.groovy
@@ -20,7 +20,9 @@ import com.twosigma.webtau.expectation.ActualPath
 import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Test
 
+import static com.twosigma.webtau.Ddjt.actual
 import static com.twosigma.webtau.Ddjt.createActualPath
+import static com.twosigma.webtau.Ddjt.equal
 import static com.twosigma.webtau.expectation.equality.CompareToComparator.AssertionMode
 import static org.junit.Assert.assertEquals
 
@@ -32,6 +34,26 @@ class IterableCompareToHandlerTest {
         def handler = new IterableCompareToHandler()
         assert handler.handleEquality([], [])
         assert !handler.handleEquality("test", [])
+    }
+
+    @Test
+    void "order should matter"() {
+        actual([1, 2]).shouldNot(equal([2, 1]))
+    }
+
+    @Test
+    void "should report matched elements"() {
+        CompareToComparator comparator = CompareToComparator.comparator(AssertionMode.EQUAL)
+        comparator.compareUsingEqualOnly(actualPath, [1, 2, 5], [1, 2, 5])
+
+        assertEquals("matches:\n" +
+                "\n" +
+                "value[0]:   actual: 1 <java.lang.Integer>\n" +
+                "          expected: 1 <java.lang.Integer>\n" +
+                "value[1]:   actual: 2 <java.lang.Integer>\n" +
+                "          expected: 2 <java.lang.Integer>\n" +
+                "value[2]:   actual: 5 <java.lang.Integer>\n" +
+                "          expected: 5 <java.lang.Integer>", comparator.generateEqualMatchReport())
     }
 
     @Test
@@ -65,5 +87,20 @@ class IterableCompareToHandlerTest {
         assertEquals("unexpected values:\n" +
             "\n" +
             "value[2]: 3", comparator.generateEqualMismatchReport())
+    }
+
+    @Test
+    void "should report matched elements in not equal mode"() {
+        actual([1, 2]).shouldNot(equal([1, 2, 3]))
+
+        CompareToComparator comparator = CompareToComparator.comparator(AssertionMode.NOT_EQUAL)
+        comparator.compareUsingEqualOnly(actualPath, [1, 2], [1, 2, 3])
+
+        assertEquals("mismatches:\n" +
+                "\n" +
+                "value[0]:   actual: 1 <java.lang.Integer>\n" +
+                "          expected: not 1 <java.lang.Integer>\n" +
+                "value[1]:   actual: 2 <java.lang.Integer>\n" +
+                "          expected: not 2 <java.lang.Integer>", comparator.generateNotEqualMismatchReport())
     }
 }

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/SetCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/SetCompareToHandlerTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.expectation.equality.handlers
+
+import com.twosigma.webtau.expectation.ActualPath
+import com.twosigma.webtau.expectation.equality.CompareToComparator
+import org.junit.Test
+
+import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.expectation.equality.CompareToComparator.AssertionMode.*
+import static org.junit.Assert.assertEquals
+
+class SetCompareToHandlerTest {
+    private static final ActualPath actualPath = createActualPath("value")
+
+    @Test
+    void "handles sets"() {
+        def handler = new SetCompareToHandler()
+        assert handler.handleEquality([] as Set, [] as Set)
+        assert !handler.handleEquality([], [] as Set)
+    }
+
+    @Test
+    void "order should not matter"() {
+        actual([1, 2] as Set).should(equal([2, 1] as Set))
+    }
+
+    @Test
+    void "should report missing and extra elements in equal mode"() {
+        CompareToComparator comparator = CompareToComparator.comparator(EQUAL)
+        comparator.compareUsingEqualOnly(actualPath,
+                ["hello", "world"] as Set,
+                [~/worl./, ~/.ello1/] as Set)
+
+        assertEquals('missing, but expected values:\n' +
+                '\n' +
+                'value: pattern /.ello1/\n' +
+                '\n' +
+                'unexpected values:\n' +
+                '\n' +
+                'value: "hello"', comparator.generateEqualMismatchReport())
+
+        println comparator.generateEqualMatchReport()
+    }
+
+    @Test
+    void "should report matched elements in not equal mode"() {
+        CompareToComparator comparator = CompareToComparator.comparator(NOT_EQUAL)
+        comparator.compareUsingEqualOnly(actualPath,
+                ["hello", "world"] as Set,
+                [~/worl./, ~/.ello1/] as Set)
+
+        assertEquals('mismatches:\n' +
+                '\n' +
+                'value[1]:   actual: "world" <java.lang.String>\n' +
+                '          expected: not pattern /worl./ <java.util.regex.Pattern>',
+                comparator.generateNotEqualMismatchReport())
+    }
+
+    @Test
+    void "should not report missing elements in not equal mode"() {
+        CompareToComparator comparator = CompareToComparator.comparator(NOT_EQUAL)
+        comparator.compareUsingEqualOnly(actualPath,
+                ["hello"] as Set,
+                [~/.ello1/] as Set)
+
+        assertEquals('', comparator.generateNotEqualMismatchReport())
+    }
+}


### PR DESCRIPTION
Closes #209.

Set comparison complexity is going to be O(NM). In this PR set contains is not used and instead equality is checked by CompareToComparator to handle cases like

```
def actual = ['hello', 'world'] as Set
actual.should == [~/wo..d/, ~/h...o/] as Set
```