### PR TITLE
Upgrade to Groovy 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,16 @@
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
-                <version>2.4.12</version>
+                <version>2.5.5</version>
+                <type>pom</type>
+                <exclusions>
+                    <!-- groovy-all includes groovy-test-junit5 which results in a compile dependency on junit5 which
+                     trips maven enforcer in some of our modules. -->
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-test-junit5</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/webtau-config/pom.xml
+++ b/webtau-config/pom.xml
@@ -44,6 +44,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-console/pom.xml
+++ b/webtau-console/pom.xml
@@ -37,6 +37,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-core-groovy/pom.xml
+++ b/webtau-core-groovy/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-core/pom.xml
+++ b/webtau-core/pom.xml
@@ -37,6 +37,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/HandlerMessagesTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/HandlerMessagesTest.groovy
@@ -221,14 +221,14 @@ class HandlerMessagesTest {
     @Test
     void "equal stream and iterable"() {
         code {
-            actual(Arrays.asList(1).stream()).should(equal(Arrays.asList(2)))
+            actual(Stream.of(1)).should(equal(Arrays.asList(2)))
         } should throwException(AssertionError, ~/expected: 2/)
     }
 
     @Test
     void "not equal stream and iterable"() {
         code {
-            actual(Arrays.asList(1).stream()).shouldNot(equal(Arrays.asList(1)))
+            actual(Stream.of(1)).shouldNot(equal(Arrays.asList(1)))
         } should throwException(AssertionError, ~/expected: not 1/)
     }
 

--- a/webtau-groovy-ast/pom.xml
+++ b/webtau-groovy-ast/pom.xml
@@ -36,6 +36,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <type>pom</type>
         </dependency>
     </dependencies>
 </project>

--- a/webtau-http-groovy/pom.xml
+++ b/webtau-http-groovy/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-json-schema/pom.xml
+++ b/webtau-json-schema/pom.xml
@@ -81,6 +81,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-open-api/pom.xml
+++ b/webtau-open-api/pom.xml
@@ -66,6 +66,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-pdf/pom.xml
+++ b/webtau-pdf/pom.xml
@@ -64,6 +64,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-report/pom.xml
+++ b/webtau-report/pom.xml
@@ -62,6 +62,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-standalone-runner-groovy/pom.xml
+++ b/webtau-standalone-runner-groovy/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-test-server/pom.xml
+++ b/webtau-test-server/pom.xml
@@ -58,6 +58,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/webtau-utils/pom.xml
+++ b/webtau-utils/pom.xml
@@ -54,6 +54,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>test</scope>
+            <type>pom</type>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes #203 .  Also reverted changes made in #204 as Groovy 2.5 fixes the underlying bug that had forced that change in the first place.  I have tested that webtau compiles and tests pass with Java 9.

Unfortunately, Groovy made a change to its packaging such that groovy-all no longer includes a fat jar.  To pull down all the necessary dependencies, we use its pom but that pulls in test modules which pull in junit so we have to exclude that.

I have also run all my tests against a local build of this PR.