### PR TITLE
NullCompareTo handler deals with greater-less. Modify mismatch messages.

### DIFF
--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/groovy/ast/ShouldAstTransformationTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/groovy/ast/ShouldAstTransformationTest.groovy
@@ -34,8 +34,7 @@ class ShouldAstTransformationTest extends GroovyTestCase {
     void testShouldNotTransformationOnNull() {
         code {
             assertScript('2.shouldNot == 2')
-        } should throwException('\nequals 2, but shouldn\'t\n' +
-            'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
             '\n' +
             '[value]:   actual: 2 <java.lang.Integer>\n' +
             '         expected: not 2 <java.lang.Integer>')
@@ -44,8 +43,7 @@ class ShouldAstTransformationTest extends GroovyTestCase {
     void testShouldTransformationOnNull() {
         code {
             assertScript('3.should == null')
-        } should throwException('\ndoesn\'t equal [null]\n' +
-            'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
             '\n' +
             '[value]:   actual: 3 <java.lang.Integer>\n' +
             '         expected: null')
@@ -54,8 +52,7 @@ class ShouldAstTransformationTest extends GroovyTestCase {
     void testShouldTransformationOnMap() {
         code {
             assertScript('[a:1, b:2].should == [a: 3]')
-        } should throwException('\ndoesn\'t equal {a=3}\n' +
-            'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
             '\n' +
             '[value].a:   actual: 1 <java.lang.Integer>\n' +
             '           expected: 3 <java.lang.Integer>\n' +
@@ -73,8 +70,7 @@ class ShouldAstTransformationTest extends GroovyTestCase {
             }
             
             code() """)
-        } should throwException('\nequals 2, but shouldn\'t\n' +
-            'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
             '\n' +
             '[value]:   actual: 2 <java.lang.Integer>\n' +
             '         expected: not 2 <java.lang.Integer>')

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/CompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/CompareToHandler.java
@@ -33,6 +33,6 @@ public interface CompareToHandler {
     void compareEqualOnly(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected);
 
     default void compareGreaterLessEqual(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
-        throw new UnsupportedOperationException("doesn't handle greater-less comparison");
+        throw new UnsupportedOperationException("greater-less comparison is not implemented");
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/EqualMatcher.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/EqualMatcher.java
@@ -41,8 +41,7 @@ public class EqualMatcher implements ValueMatcher {
 
     @Override
     public String mismatchedMessage(ActualPath actualPath, Object actual) {
-        return "doesn't equal " + DataRenderers.render(expected) + "\n" +
-                comparator.generateEqualMismatchReport();
+        return comparator.generateEqualMismatchReport();
     }
 
     @Override
@@ -64,8 +63,7 @@ public class EqualMatcher implements ValueMatcher {
 
     @Override
     public String negativeMismatchedMessage(ActualPath actualPath, Object actual) {
-        return "equals " + DataRenderers.render(expected) + ", but shouldn't\n" +
-                comparator.generateNotEqualMismatchReport();
+        return comparator.generateNotEqualMismatchReport();
     }
 
     @Override

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/GreaterThanMatcher.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/GreaterThanMatcher.java
@@ -41,8 +41,7 @@ public class GreaterThanMatcher implements ValueMatcher {
 
     @Override
     public String mismatchedMessage(ActualPath actualPath, Object actual) {
-        return "less then or equal to " + DataRenderers.render(expected) + "\n" +
-                compareToComparator.generateGreaterThanMismatchReport();
+        return compareToComparator.generateGreaterThanMismatchReport();
     }
 
     @Override
@@ -64,9 +63,7 @@ public class GreaterThanMatcher implements ValueMatcher {
 
     @Override
     public String negativeMismatchedMessage(ActualPath actualPath, Object actual) {
-        return actualPath + " is greater than " + DataRenderers.render(expected) +
-                ", but should be less or equal to\n" +
-                compareToComparator.generateLessThanOrEqualMismatchReport();
+        return compareToComparator.generateLessThanOrEqualMismatchReport();
     }
 
     @Override

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/GreaterThanOrEqualMatcher.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/GreaterThanOrEqualMatcher.java
@@ -41,8 +41,7 @@ public class GreaterThanOrEqualMatcher implements ValueMatcher {
 
     @Override
     public String mismatchedMessage(ActualPath actualPath, Object actual) {
-        return "less then " + DataRenderers.render(expected) + "\n" +
-                compareToComparator.generateGreaterThanOrEqualMismatchReport();
+        return compareToComparator.generateGreaterThanOrEqualMismatchReport();
     }
 
     @Override
@@ -64,9 +63,7 @@ public class GreaterThanOrEqualMatcher implements ValueMatcher {
 
     @Override
     public String negativeMismatchedMessage(ActualPath actualPath, Object actual) {
-        return actualPath + " is greater than or equal to " + DataRenderers.render(expected) +
-                ", but should be less\n" +
-                compareToComparator.generateLessThanMismatchReport();
+        return compareToComparator.generateLessThanMismatchReport();
     }
 
     @Override

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/LessThanMatcher.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/LessThanMatcher.java
@@ -41,8 +41,7 @@ public class LessThanMatcher implements ValueMatcher {
 
     @Override
     public String mismatchedMessage(ActualPath actualPath, Object actual) {
-        return "greater then or equal to " + DataRenderers.render(expected) + "\n" +
-                compareToComparator.generateLessThanMismatchReport();
+        return compareToComparator.generateLessThanMismatchReport();
     }
 
     @Override
@@ -64,9 +63,7 @@ public class LessThanMatcher implements ValueMatcher {
 
     @Override
     public String negativeMismatchedMessage(ActualPath actualPath, Object actual) {
-        return actualPath + " is less than " + DataRenderers.render(expected) +
-                ", but should be greater or equal to\n" +
-                compareToComparator.generateGreaterThanOrEqualMismatchReport();
+        return compareToComparator.generateGreaterThanOrEqualMismatchReport();
     }
 
     @Override

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/LessThanOrEqualMatcher.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/LessThanOrEqualMatcher.java
@@ -41,8 +41,7 @@ public class LessThanOrEqualMatcher implements ValueMatcher {
 
     @Override
     public String mismatchedMessage(ActualPath actualPath, Object actual) {
-        return "greater then " + DataRenderers.render(expected) + "\n" +
-                compareToComparator.generateLessThanOrEqualMismatchReport();
+        return compareToComparator.generateLessThanOrEqualMismatchReport();
     }
 
     @Override
@@ -64,9 +63,7 @@ public class LessThanOrEqualMatcher implements ValueMatcher {
 
     @Override
     public String negativeMismatchedMessage(ActualPath actualPath, Object actual) {
-        return actualPath + " is less than or equal to " + DataRenderers.render(expected) +
-                ", but should be greater\n" +
-                compareToComparator.generateGreaterThanMismatchReport();
+        return compareToComparator.generateGreaterThanMismatchReport();
     }
 
     @Override

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NullCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NullCompareToHandler.java
@@ -18,6 +18,7 @@ package com.twosigma.webtau.expectation.equality.handlers;
 
 import com.twosigma.webtau.expectation.ActualPath;
 import com.twosigma.webtau.expectation.equality.CompareToComparator;
+import com.twosigma.webtau.expectation.equality.CompareToComparator.AssertionMode;
 import com.twosigma.webtau.expectation.equality.CompareToHandler;
 
 import static com.twosigma.webtau.expectation.equality.handlers.HandlerMessages.expected;
@@ -26,7 +27,12 @@ import static com.twosigma.webtau.utils.TraceUtils.renderValueAndType;
 public class NullCompareToHandler implements CompareToHandler {
     @Override
     public boolean handleEquality(Object actual, Object expected) {
-        return actual == null || expected == null;
+        return eitherIsNull(actual, expected);
+    }
+
+    @Override
+    public boolean handleGreaterLessEqual(Object actual, Object expected) {
+        return eitherIsNull(actual, expected);
     }
 
     @Override
@@ -46,5 +52,44 @@ public class NullCompareToHandler implements CompareToHandler {
             comparator.reportNotEqual(this, actualPath,
                     "  actual: " + renderValueAndType(actual) + "\n" + expected(comparator.getAssertionMode(), null));
         }
+    }
+
+    @Override
+    public void compareGreaterLessEqual(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
+        if (actual == null && expected == null && checksEquality(comparator)) {
+            comparator.reportEqual(this, actualPath,
+                    "  actual: null\n" + expected(comparator.getAssertionMode(), null));
+        } else if (actual == null) {
+            String message = "  actual: null\n" + expected(comparator.getAssertionMode(), renderValueAndType(expected));
+            generateOppositeReport(comparator, actualPath, message);
+        } else {
+            String message = "  actual: " + renderValueAndType(actual) + "\n" + expected(comparator.getAssertionMode(),
+                    null);
+            generateOppositeReport(comparator, actualPath, message);
+        }
+    }
+
+    private void generateOppositeReport(CompareToComparator comparator, ActualPath actualPath, String message) {
+        switch (comparator.getAssertionMode()) {
+            case GREATER_THAN:
+            case GREATER_THAN_OR_EQUAL:
+                comparator.reportLess(this, actualPath, message);
+                break;
+            case LESS_THAN:
+            case LESS_THAN_OR_EQUAL:
+                comparator.reportGreater(this, actualPath, message);
+                break;
+        }
+    }
+
+    private boolean checksEquality(CompareToComparator comparator) {
+        return comparator.getAssertionMode() == AssertionMode.EQUAL ||
+                comparator.getAssertionMode() == AssertionMode.NOT_EQUAL ||
+                comparator.getAssertionMode() == AssertionMode.LESS_THAN_OR_EQUAL ||
+                comparator.getAssertionMode() == AssertionMode.GREATER_THAN_OR_EQUAL;
+    }
+
+    private boolean eitherIsNull(Object actual, Object expected) {
+        return actual == null || expected == null;
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NumbersCompareToHandler.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/equality/handlers/NumbersCompareToHandler.java
@@ -23,8 +23,6 @@ import com.twosigma.webtau.expectation.equality.CompareToHandler;
 import java.math.BigDecimal;
 import java.util.Scanner;
 
-import static com.twosigma.webtau.utils.TraceUtils.renderValueAndType;
-
 public class NumbersCompareToHandler implements CompareToHandler {
     @Override
     public boolean handleEquality(Object actual, Object expected) {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/ActualValueTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/ActualValueTest.groovy
@@ -70,7 +70,7 @@ class ActualValueTest {
     @Test
     void "custom handler for waitToNot"() {
         def expectationTimer = new DummyExpectationTimer(2)
-        testCustomHandler('equals 1') {
+        testCustomHandler('actual: 1') {
             actual(ones).waitToNot(equal(1), expectationTimer, 1000, 10)
         }
     }
@@ -84,7 +84,7 @@ class ActualValueTest {
 
     @Test
     void "custom handler for shouldNot"() {
-        testCustomHandler('equals 1') {
+        testCustomHandler('actual: 1') {
             actual(ones).shouldNot(equal(1))
         }
     }

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/EqualMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/EqualMatcherTest.groovy
@@ -40,8 +40,7 @@ class EqualMatcherTest {
         def actual = expected + 1
         assert !matcher.matches(actualPath, actual)
 
-        assert matcher.mismatchedMessage(actualPath, actual) ==  "doesn't equal $expected\n" +
-            "mismatches:\n\n" +
+        assert matcher.mismatchedMessage(actualPath, actual) == "mismatches:\n\n" +
             simpleActualExpectedWithIntegers(actual, expected)
     }
 
@@ -58,8 +57,7 @@ class EqualMatcherTest {
     void "negative mismatch"() {
         def actual = expected
         assert !matcher.negativeMatches(actualPath, actual)
-        assert matcher.negativeMismatchedMessage(actualPath, actual) ==  "equals $expected, but shouldn't\n" +
-            "mismatches:\n\n" +
+        assert matcher.negativeMismatchedMessage(actualPath, actual) == "mismatches:\n\n" +
             simpleActualExpectedWithIntegers(actual, "not", expected)
     }
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/GreaterThanMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/GreaterThanMatcherTest.groovy
@@ -41,8 +41,7 @@ class GreaterThanMatcherTest {
     void "positive mismatch"() {
         def actual = expected
         assert !matcher.matches(actualPath, actual)
-        assert matcher.mismatchedMessage(actualPath, actual) ==  "less then or equal to $expected\n" +
-            'mismatches:\n\n' +
+        assert matcher.mismatchedMessage(actualPath, actual) == 'mismatches:\n\n' +
             simpleActualExpectedWithIntegers(actual, "greater than", expected)
     }
 
@@ -59,8 +58,7 @@ class GreaterThanMatcherTest {
     void "negative mismatch"() {
         def actual = expected + 1
         assert !matcher.negativeMatches(actualPath, actual)
-        assert matcher.negativeMismatchedMessage(actualPath, actual) ==  "value is greater than $expected, but should be less or equal to\n" +
-            'mismatches:\n\n' +
+        assert matcher.negativeMismatchedMessage(actualPath, actual) == 'mismatches:\n\n' +
             simpleActualExpectedWithIntegers(actual, "less than or equal to", expected)
     }
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/GreaterThanOrEqualMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/GreaterThanOrEqualMatcherTest.groovy
@@ -47,8 +47,7 @@ class GreaterThanOrEqualMatcherTest {
     void "positive mismatch"() {
         def actual = expected - 1
         assert !matcher.matches(actualPath, actual)
-        assert matcher.mismatchedMessage(actualPath, actual) ==  "less then $expected\n" +
-            'mismatches:\n\n' +
+        assert matcher.mismatchedMessage(actualPath, actual) == 'mismatches:\n\n' +
             simpleActualExpectedWithIntegers(actual, "greater than or equal to", expected)
     }
 
@@ -73,8 +72,7 @@ class GreaterThanOrEqualMatcherTest {
 
     private void assertNegativeMismatch(int actual) {
         assert !matcher.negativeMatches(actualPath, actual)
-        assert matcher.negativeMismatchedMessage(actualPath, actual) == "value is greater than or equal to $expected, but should be less\n" +
-            'mismatches:\n\n' +
+        assert matcher.negativeMismatchedMessage(actualPath, actual) == 'mismatches:\n\n' +
             simpleActualExpectedWithIntegers(actual, "less than", expected)
     }
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/LessThanMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/LessThanMatcherTest.groovy
@@ -41,8 +41,7 @@ class LessThanMatcherTest {
     void "positive mismatch"() {
         def actual = expected
         assert !matcher.matches(actualPath, actual)
-        assert matcher.mismatchedMessage(actualPath, actual) ==  "greater then or equal to $expected\n" +
-            'mismatches:\n\n' +
+        assert matcher.mismatchedMessage(actualPath, actual) == 'mismatches:\n\n' +
             simpleActualExpectedWithIntegers(actual, "less than", expected)
     }
 
@@ -59,8 +58,7 @@ class LessThanMatcherTest {
     void "negative mismatch"() {
         def actual = expected - 1
         assert !matcher.negativeMatches(actualPath, actual)
-        assert matcher.negativeMismatchedMessage(actualPath, actual) ==  "value is less than $expected, but should be greater or equal to\n" +
-            'mismatches:\n\n' +
+        assert matcher.negativeMismatchedMessage(actualPath, actual) == 'mismatches:\n\n' +
             simpleActualExpectedWithIntegers(actual, "greater than or equal to", expected)
     }
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/LessThanOrEqualMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/LessThanOrEqualMatcherTest.groovy
@@ -47,8 +47,7 @@ class LessThanOrEqualMatcherTest {
     void "positive mismatch"() {
         def actual = expected + 1
         assert !matcher.matches(actualPath, actual)
-        assert matcher.mismatchedMessage(actualPath, actual) ==  "greater then $expected\n" +
-            'mismatches:\n\n' +
+        assert matcher.mismatchedMessage(actualPath, actual) == 'mismatches:\n\n' +
             simpleActualExpectedWithIntegers(actual, "less than or equal to", expected)
     }
 
@@ -73,8 +72,7 @@ class LessThanOrEqualMatcherTest {
 
     private void assertNegativeMismatch(int actual) {
         assert !matcher.negativeMatches(actualPath, actual)
-        assert matcher.negativeMismatchedMessage(actualPath, actual) == "value is less than or equal to $expected, but should be greater\n" +
-            'mismatches:\n\n' +
+        assert matcher.negativeMismatchedMessage(actualPath, actual) == 'mismatches:\n\n' +
             simpleActualExpectedWithIntegers(actual, "greater than", expected)
     }
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/DateAndStringCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/DateAndStringCompareToHandlerTest.groovy
@@ -51,8 +51,7 @@ class DateAndStringCompareToHandlerTest {
     void "actual local date string doesn't equal expected local date instance"() {
         code {
             actual("2018-06-10").should(equal(LocalDate.of(2018, 6, 9)))
-        } should throwException("\ndoesn't equal 2018-06-09\n" +
-            "mismatches:\n" +
+        } should throwException("\nmismatches:\n" +
             "\n" +
             "[value]:   actual: 2018-06-10 <java.time.LocalDate>\n" +
             "         expected: 2018-06-09 <java.time.LocalDate>")
@@ -67,7 +66,7 @@ class DateAndStringCompareToHandlerTest {
     void "actual zoned date time string equals expected local date instance, when should be greater"() {
         code {
             actual("2018-01-01T00:00:00Z").should(beGreaterThan(LocalDate.of(2018, 1, 1)))
-        } should throwException("\nless then or equal to 2018-01-01\nmismatches:\n\n" +
+        } should throwException("\nmismatches:\n\n" +
             "[value]:   actual: 2018-01-01T00:00Z <java.time.ZonedDateTime>\n" +
             "         expected: greater than 2018-01-01 <java.time.LocalDate>")
     }
@@ -89,8 +88,7 @@ class DateAndStringCompareToHandlerTest {
         code {
             actual("2018-01-02T10:00:00+01:00:00").should(beGreaterThan(
                 ZonedDateTime.of(2018, 1, 2, 10, 0, 0, 0, ZoneId.of("UTC"))))
-        } should throwException("\nless then or equal to 2018-01-02T10:00Z[UTC]\n" +
-            "mismatches:\n" +
+        } should throwException("\nmismatches:\n" +
             "\n" +
             "[value]:   actual: 2018-01-02T10:00+01:00 <java.time.ZonedDateTime>(UTC normalized: 2018-01-02T09:00Z[UTC])\n" +
             "         expected: greater than 2018-01-02T10:00Z[UTC] <java.time.ZonedDateTime>(UTC normalized: 2018-01-02T10:00Z[UTC])")

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NullCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NullCompareToHandlerTest.groovy
@@ -16,12 +16,10 @@
 
 package com.twosigma.webtau.expectation.equality.handlers
 
+import com.twosigma.webtau.expectation.ValueMatcher
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.equal
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.Ddjt.*
 
 class NullCompareToHandlerTest {
     @Test
@@ -29,15 +27,20 @@ class NullCompareToHandlerTest {
         def handler = new NullCompareToHandler()
 
         assert handler.handleNulls()
+
         assert handler.handleEquality(null, "hello")
         assert handler.handleEquality("hello", null)
         assert handler.handleEquality(null, null)
-
         assert !handler.handleEquality(10, "world")
+
+        assert handler.handleGreaterLessEqual(null, "hello")
+        assert handler.handleGreaterLessEqual("hello", null)
+        assert handler.handleGreaterLessEqual(null, null)
+        assert !handler.handleGreaterLessEqual(10, "world")
     }
 
     @Test
-    void "handler is linked"() {
+    void "provides clear error message for equality check with null"() {
         actual(null).should(equal(null))
         actual("hello").shouldNot(equal(null))
         actual(null).shouldNot(equal("hello"))
@@ -49,5 +52,43 @@ class NullCompareToHandlerTest {
         code {
             actual(null).should(equal(10))
         } should throwException(AssertionError, ~/expected: 10/)
+    }
+
+    @Test
+    void "null is greater-than-or-equal and less-than-or-equal than null"() {
+        actual(null).should(beGreaterThanOrEqual(null))
+        actual(null).should(beLessThanOrEqual(null))
+    }
+
+    @Test
+    void "provides clear error message for greater-less check with actual equal to null"() {
+        def expect = { ValueMatcher matcher, String expectedMessage ->
+            code {
+                actual(null).should(matcher)
+            } should throwException(~/actual: null\n.*${expectedMessage}/)
+
+        }
+
+        expect(beGreaterThan(10), "expected: greater than 10")
+        expect(beGreaterThanOrEqual(10), "expected: greater than or equal to 10")
+
+        expect(beLessThan(10), "expected: less than 10")
+        expect(beLessThanOrEqual(10), "expected: less than or equal to 10")
+    }
+
+    @Test
+    void "provides clear error message for greater-less check with expected equal to null"() {
+        def expect = { ValueMatcher matcher, String expectedMessage ->
+            code {
+                actual(10).should(matcher)
+            } should throwException(~/actual: 10.*\n.*${expectedMessage}/)
+
+        }
+
+        expect(beGreaterThan(null), "expected: greater than null")
+        expect(beGreaterThanOrEqual(null), "expected: greater than or equal to null")
+
+        expect(beLessThan(null), "expected: less than null")
+        expect(beLessThanOrEqual(null), "expected: less than or equal to null")
     }
 }

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -79,8 +79,7 @@ class HttpGroovyTest implements HttpConfiguration {
             http.post("/echo", [a: null]) {
                 a.shouldNot == null
             }
-        } should throwException('\nequals [null], but shouldn\'t\n' +
-            'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
             '\n' +
             'body.a:   actual: null\n' +
             '        expected: not null')
@@ -771,8 +770,7 @@ class HttpGroovyTest implements HttpConfiguration {
     void "implicit status code check when no explicit check present"() {
         code {
             def id = http.get("/no-resource") { id }
-        } should throwException('\ndoesn\'t equal 200\n' +
-            'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
             '\n' +
             'header.statusCode:   actual: 404 <java.lang.Integer>\n' +
             '                   expected: 200 <java.lang.Integer>')
@@ -791,8 +789,7 @@ class HttpGroovyTest implements HttpConfiguration {
                 id.should == 0
                 message.shouldBe == 10
             }
-        } should throwException('\ndoesn\'t equal 200\n' +
-                    'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
                     '\n' +
                     'header.statusCode:   actual: 404 <java.lang.Integer>\n' +
                     '                   expected: 200 <java.lang.Integer>')
@@ -806,8 +803,7 @@ class HttpGroovyTest implements HttpConfiguration {
             http.get("/no-resource") {
                 throw new RuntimeException('error')
             }
-        } should throwException('\ndoesn\'t equal 200\n' +
-                'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
                 '\n' +
                 'header.statusCode:   actual: 404 <java.lang.Integer>\n' +
                 '                   expected: 200 <java.lang.Integer>\n' +
@@ -824,8 +820,7 @@ class HttpGroovyTest implements HttpConfiguration {
             http.get("/no-resource") {
                 statusCode.should == 401
             }
-        } should throwException('\ndoesn\'t equal 401\n' +
-                'mismatches:\n' +
+        } should throwException('\nmismatches:\n' +
                 '\n' +
                 'header.statusCode:   actual: 404 <java.lang.Integer>\n' +
                 '                   expected: 401 <java.lang.Integer>')

--- a/webtau-http/src/test/groovy/com/twosigma/webtau/http/datanode/StructuredDataNodeTest.groovy
+++ b/webtau-http/src/test/groovy/com/twosigma/webtau/http/datanode/StructuredDataNodeTest.groovy
@@ -58,7 +58,7 @@ class StructuredDataNodeTest {
 
         code {
             node.shouldNot(equal(10))
-        } should throwException(~/equals 10/)
+        } should throwException(~/actual: 10/)
 
         node.getTraceableValue().checkLevel.should == CheckLevel.ExplicitFailed
     }

--- a/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
+++ b/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
@@ -40,7 +40,7 @@ class StandaloneTestRunnerTest {
 
         runner.tests[1].hasError().should == false
         runner.tests[1].isFailed().should == true
-        runner.tests[1].assertionMessage.should == "\ndoesn't equal 11\nmismatches:\n" +
+        runner.tests[1].assertionMessage.should == "\nmismatches:\n" +
                 "\n" +
                 "[value]:   actual: 10 <java.lang.Integer>\n" +
                 "         expected: 11 <java.lang.Integer>"


### PR DESCRIPTION
This closes #259.

Since we are more precise in mismatch reporting now, Equal and Greater/Less Matchers do not provide summary text in case of mismatch anymore. Instead they solely rely on the generated Comparator mismatch report. 
Main motivation for the change is comparisons like `(null|value).shouldBe > (number|null)`. Matcher would provide additional message like "null is less than number" which would be inaccurate in case of nulls. 