### PR TITLE
update webdrivermanager to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,10 @@
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-test-junit5</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <artifactId>testng</artifactId>
+                        <groupId>org.testng</groupId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
                 <version>2.5.5</version>
@@ -194,7 +199,7 @@
             <dependency>
                 <groupId>io.github.bonigarcia</groupId>
                 <artifactId>webdrivermanager</artifactId>
-                <version>3.0.0</version>
+                <version>3.4.0</version>
             </dependency>
 
             <dependency>

--- a/webtau-browser/pom.xml
+++ b/webtau-browser/pom.xml
@@ -28,7 +28,7 @@
     <version>1.7-SNAPSHOT</version>
 
     <properties>
-        <selenium.version>3.13.0</selenium.version>
+        <selenium.version>3.141.59</selenium.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The current wdm version (3.0.0) has no mapping for later versions of chrome and defaults to the latest chromedriver v74, which at this time is only compatible with a dev version of Chrome, and does not match the installed version (73).
This latest version pulls the correct version matching the installed chrome version.
