### PR TITLE
add cell.above to refer to previous row value

### DIFF
--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/table/TableDataExtensionTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/table/TableDataExtensionTest.groovy
@@ -59,6 +59,15 @@ class TableDataExtensionTest {
     }
 
     @Test
+    void "cell previous should be substituted with value from a previous row"() {
+        def tableData = createTableDataWithPreviousRef()
+        assert tableData.numberOfRows() == 3
+        assert tableData.row(0).toMap() == ["Col A": "v1a", "Col B": "v1b", "Col C": 10]
+        assert tableData.row(1).toMap() == ["Col A": "v2a", "Col B": "v2b", "Col C": 10]
+        assert tableData.row(2).toMap() == ["Col A": "v2a", "Col B": "v2b", "Col C": 20]
+    }
+
+    @Test
     void "should ignore underscore under header"() {
         def table = ["hello" | "world"] {
                     ___________________
@@ -85,6 +94,14 @@ class TableDataExtensionTest {
         ___________________________________________________________
          permute(true, false) | "v1b"           | permute('a', 'b')
          "v2a"                | permute(10, 20) | "v2c" }
+    }
+
+    static TableData createTableDataWithPreviousRef() {
+        ["Col A" | "Col B" | "Col C"] {
+        __________________________________________
+            "v1a" |   "v1b" | 10
+            "v2a" |   "v2b" | cell.previous
+            "v2a" |   "v2b" | cell.previous + 10 }
     }
 
     private static void validateTableData(TableData tableData) {

--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/table/TableDataExtensionTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/table/TableDataExtensionTest.groovy
@@ -99,9 +99,9 @@ class TableDataExtensionTest {
     static TableData createTableDataWithPreviousRef() {
         ["Col A" | "Col B" | "Col C"] {
         __________________________________________
-            "v1a" |   "v1b" | 10
-            "v2a" |   "v2b" | cell.previous
-            "v2a" |   "v2b" | cell.previous + 10 }
+           "v1a" |   "v1b" | 10
+           "v2a" |   "v2b" | cell.previous
+           "v2a" |   "v2b" | cell.previous + 10 }
     }
 
     private static void validateTableData(TableData tableData) {

--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/table/TableDataExtensionTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/table/TableDataExtensionTest.groovy
@@ -100,8 +100,8 @@ class TableDataExtensionTest {
         ["Col A" | "Col B" | "Col C"] {
         __________________________________________
            "v1a" |   "v1b" | 10
-           "v2a" |   "v2b" | cell.previous
-           "v2a" |   "v2b" | cell.previous + 10 }
+           "v2a" |   "v2b" | cell.above
+           "v2a" |   "v2b" | cell.above + 10 }
     }
 
     private static void validateTableData(TableData tableData) {

--- a/webtau-core/src/main/java/com/twosigma/webtau/Ddjt.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/Ddjt.java
@@ -17,6 +17,9 @@
 package com.twosigma.webtau;
 
 import com.twosigma.webtau.data.table.TableData;
+import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenFullFunction;
+import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenOnlyRecordFunction;
+import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenerator;
 import com.twosigma.webtau.data.table.TableDataUnderscoreOrPlaceholder;
 import com.twosigma.webtau.expectation.ActualCode;
 import com.twosigma.webtau.expectation.ActualCodeExpectations;
@@ -60,6 +63,14 @@ public class Ddjt {
 
     public static TableData table(Object... columnNames) {
         return new TableData(Arrays.stream(columnNames));
+    }
+
+    public static <R> TableDataCellValueGenerator<R> cellValue(TableDataCellValueGenFullFunction<R> genFunction) {
+        return new TableDataCellValueGenerator<>(genFunction);
+    }
+
+    public static <R> TableDataCellValueGenerator<R> cellValue(TableDataCellValueGenOnlyRecordFunction<R> genFunction) {
+        return new TableDataCellValueGenerator<>(genFunction);
     }
 
     public static ActualValueExpectations actual(Object actual) {

--- a/webtau-core/src/main/java/com/twosigma/webtau/Ddjt.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/Ddjt.java
@@ -18,6 +18,7 @@ package com.twosigma.webtau;
 
 import com.twosigma.webtau.data.table.TableData;
 import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenFullFunction;
+import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenFunctions;
 import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenOnlyRecordFunction;
 import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenerator;
 import com.twosigma.webtau.data.table.TableDataUnderscoreOrPlaceholder;
@@ -56,6 +57,8 @@ public class Ddjt {
     public static final TableDataUnderscoreOrPlaceholder ________________________________________________________________ = TableDataUnderscoreOrPlaceholder.INSTANCE;
     public static final TableDataUnderscoreOrPlaceholder ________________________________________________________________________________ = TableDataUnderscoreOrPlaceholder.INSTANCE;
     public static final TableDataUnderscoreOrPlaceholder ________________________________________________________________________________________________ = TableDataUnderscoreOrPlaceholder.INSTANCE;
+
+    public static final TableDataCellValueGenFunctions cell = new TableDataCellValueGenFunctions();
 
     public static TableData table(String... columnNames) {
         return new TableData(Arrays.stream(columnNames));

--- a/webtau-core/src/main/java/com/twosigma/webtau/Ddjt.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/Ddjt.java
@@ -18,10 +18,7 @@ package com.twosigma.webtau;
 
 import com.twosigma.webtau.data.MultiValue;
 import com.twosigma.webtau.data.table.TableData;
-import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenFullFunction;
 import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenFunctions;
-import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenOnlyRecordFunction;
-import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenerator;
 import com.twosigma.webtau.data.table.TableDataUnderscoreOrPlaceholder;
 import com.twosigma.webtau.expectation.ActualCode;
 import com.twosigma.webtau.expectation.ActualCodeExpectations;
@@ -71,14 +68,6 @@ public class Ddjt {
 
     public static MultiValue permute(Object atLeastOneValue, Object... values) {
         return new MultiValue(atLeastOneValue, values);
-    }
-
-    public static <R> TableDataCellValueGenerator<R> cellValue(TableDataCellValueGenFullFunction<R> genFunction) {
-        return new TableDataCellValueGenerator<>(genFunction);
-    }
-
-    public static <R> TableDataCellValueGenerator<R> cellValue(TableDataCellValueGenOnlyRecordFunction<R> genFunction) {
-        return new TableDataCellValueGenerator<>(genFunction);
     }
 
     public static ActualValueExpectations actual(Object actual) {

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/Record.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/Record.java
@@ -17,24 +17,28 @@
 package com.twosigma.webtau.data.table;
 
 import com.twosigma.webtau.data.MultiValue;
+import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenerator;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
 
 public class Record {
     private final Header header;
     private final List<Object> values;
     private final CompositeKey key;
 
+    private final boolean hasMultiValues;
+    private final boolean hasValueGenerators;
+
     public Record(Header header, Stream<Object> values) {
         this.header = header;
-        this.values = values.collect(toList());
+        RecordFromStream recordFromStream = new RecordFromStream(values);
+
+        hasMultiValues = recordFromStream.hasMultiValues;
+        hasValueGenerators = recordFromStream.hasValueGenerators;
+        this.values = recordFromStream.values;
+
         this.key = header.hasKeyColumns() ?
                 new CompositeKey(header.getKeyIdxStream().map(this::get)) : null;
     }
@@ -63,7 +67,11 @@ public class Record {
     }
 
     public boolean hasMultiValues() {
-        return this.values.stream().anyMatch(v -> v instanceof MultiValue);
+        return this.hasMultiValues;
+    }
+
+    public boolean hasValueGenerators() {
+        return this.hasValueGenerators;
     }
 
     @SuppressWarnings("unchecked")
@@ -76,6 +84,27 @@ public class Record {
         multiValuesUnwrapper.add(this);
 
         return multiValuesUnwrapper.result;
+    }
+
+    public Record evaluateValueGenerators(Record previous, int rowIdx) {
+        if (!hasValueGenerators()) {
+            return this;
+        }
+
+        List<Object> newValues = new ArrayList<>(this.values.size());
+        int colIdx = 0;
+        for (Object value : this.values) {
+            if (value instanceof TableDataCellValueGenerator) {
+                newValues.add(((TableDataCellValueGenerator) value).generate(
+                        this, previous, rowIdx, colIdx, header.columnNameByIdx(colIdx)));
+            } else {
+                newValues.add(value);
+            }
+
+            colIdx++;
+        }
+
+        return new Record(header, newValues.stream());
     }
 
     public Map<String, Object> toMap() {
@@ -116,6 +145,29 @@ public class Record {
             }
 
             result.add(record);
+        }
+    }
+
+    private static class RecordFromStream {
+        private boolean hasMultiValues;
+        private boolean hasValueGenerators;
+        private List<Object> values;
+
+        public RecordFromStream(Stream<Object> valuesStream) {
+            values = new ArrayList<>();
+            Iterator<Object> it = valuesStream.iterator();
+            while (it.hasNext()) {
+                Object v = it.next();
+                if (v instanceof MultiValue) {
+                    hasMultiValues = true;
+                }
+
+                if (v instanceof TableDataCellValueGenerator) {
+                    hasValueGenerators = true;
+                }
+
+                values.add(v);
+            }
         }
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/Record.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/Record.java
@@ -155,9 +155,8 @@ public class Record {
 
         public RecordFromStream(Stream<Object> valuesStream) {
             values = new ArrayList<>();
-            Iterator<Object> it = valuesStream.iterator();
-            while (it.hasNext()) {
-                Object v = it.next();
+
+            valuesStream.forEach(v -> {
                 if (v instanceof MultiValue) {
                     hasMultiValues = true;
                 }
@@ -167,7 +166,7 @@ public class Record {
                 }
 
                 values.add(v);
-            }
+            });
         }
     }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/TableData.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/TableData.java
@@ -120,15 +120,18 @@ public class TableData implements Iterable<Record> {
         int rowIdx = rows.size();
         CompositeKey key = getOrBuildKey(rowIdx, record);
 
-        Record previous = rowsByKey.put(key, record);
-        if (previous != null) {
+        Record existing = rowsByKey.put(key, record);
+        if (existing != null) {
             throw new IllegalArgumentException("duplicate entry found with key: " + key +
-                    "\n" + previous +
+                    "\n" + existing +
                     "\n" + record);
         }
 
+        Record previous = rows.isEmpty() ? null : rows.get(rows.size() - 1);
+        Record withEvaluatedGenerators = record.evaluateValueGenerators(previous, rows.size());
+
         rowIdxByKey.put(key, rowIdx);
-        rows.add(record);
+        rows.add(withEvaluatedGenerators);
     }
 
     public TableData map(TableDataCellMapFunction mapper) {

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/TableData.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/TableData.java
@@ -126,7 +126,7 @@ public class TableData implements Iterable<Record> {
         rows.add(record);
     }
 
-    public TableData map(TableDataCellFunction mapper) {
+    public TableData map(TableDataCellMapFunction mapper) {
         TableData mapped = new TableData(header);
 
         int rowIdx = 0;
@@ -145,7 +145,7 @@ public class TableData implements Iterable<Record> {
     }
 
     @SuppressWarnings("unchecked")
-    private <T, R> Stream<Object> mapRow(int rowIdx, Record originalRow, TableDataCellFunction mapper) {
+    private <T, R> Stream<Object> mapRow(int rowIdx, Record originalRow, TableDataCellMapFunction mapper) {
         return header.getColumnIdxStream()
                 .mapToObj(idx -> mapper.apply(rowIdx, idx, header.columnNameByIdx(idx), originalRow.get(idx)));
     }

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/TableDataCellMapFunction.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/TableDataCellMapFunction.java
@@ -16,6 +16,6 @@
 
 package com.twosigma.webtau.data.table;
 
-public interface TableDataCellFunction<T, R> {
+public interface TableDataCellMapFunction<T, R> {
     R apply(int rowIdx, int colIdx, String columnName, T v);
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFullFunction.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFullFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.data.table.autogen;
+
+import com.twosigma.webtau.data.table.Record;
+
+public interface TableDataCellValueGenFullFunction<R> {
+    R apply(Record row, Record prev, int rowIdx, int colIdx, String columnName);
+}

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFunctions.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFunctions.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.data.table.autogen;
+
+import com.twosigma.webtau.data.table.Record;
+
+/**
+ * @see com.twosigma.webtau.Ddjt#cell
+ */
+public class TableDataCellValueGenFunctions {
+    public final TableDataCellValueGenerator<?> previous = new TableDataCellValueGenerator<>(this::previousColumnValue);
+
+    private <R> R previousColumnValue(Record row, Record prev, int rowIdx, int colIdx, String columnName) {
+        if (prev == null) {
+            return null;
+        }
+
+        return prev.get(columnName);
+    }
+}

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFunctions.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFunctions.java
@@ -24,6 +24,14 @@ import com.twosigma.webtau.data.table.Record;
 public class TableDataCellValueGenFunctions {
     public final TableDataCellValueGenerator<?> previous = new TableDataCellValueGenerator<>(this::previousColumnValue);
 
+    public static <R> TableDataCellValueGenerator<R> value(TableDataCellValueGenFullFunction<R> genFunction) {
+        return new TableDataCellValueGenerator<>(genFunction);
+    }
+
+    public static <R> TableDataCellValueGenerator<R> value(TableDataCellValueGenOnlyRecordFunction<R> genFunction) {
+        return new TableDataCellValueGenerator<>(genFunction);
+    }
+
     private <R> R previousColumnValue(Record row, Record prev, int rowIdx, int colIdx, String columnName) {
         if (prev == null) {
             return null;

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFunctions.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFunctions.java
@@ -22,7 +22,7 @@ import com.twosigma.webtau.data.table.Record;
  * @see com.twosigma.webtau.Ddjt#cell
  */
 public class TableDataCellValueGenFunctions {
-    public final TableDataCellValueGenerator<?> previous = new TableDataCellValueGenerator<>(this::previousColumnValue);
+    public final TableDataCellValueGenerator<?> above = new TableDataCellValueGenerator<>(this::previousColumnValue);
 
     public static <R> TableDataCellValueGenerator<R> value(TableDataCellValueGenFullFunction<R> genFunction) {
         return new TableDataCellValueGenerator<>(genFunction);

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenOnlyRecordFunction.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenOnlyRecordFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.data.table.autogen;
+
+import com.twosigma.webtau.data.table.Record;
+
+public interface TableDataCellValueGenOnlyRecordFunction<R> {
+    R apply(Record row);
+}

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenerator.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenerator.java
@@ -37,4 +37,28 @@ public class TableDataCellValueGenerator<R> {
             return genFunction.apply(row, prev, rowIdx, colIdx, columnName);
         }
     }
+
+    @SuppressWarnings("unchecked")
+    public <N extends Number> TableDataCellValueGenerator<N> plus(Number v) {
+        return new TableDataCellValueGenerator<N>(((row, prev, rowIdx, colIdx, columnName) -> {
+            R calculated = genFunction.apply(row, prev, rowIdx, colIdx, columnName);
+            return (N) addTwoNumbers((Number) calculated, v);
+        }));
+    }
+
+    private static Number addTwoNumbers(Number a, Number b) {
+        if (b instanceof Double) {
+            return a.doubleValue() + b.doubleValue();
+        }
+
+        if (a instanceof Long || b instanceof Long) {
+            return a.longValue() + b.longValue();
+        }
+
+        if (b instanceof Integer) {
+            return a.intValue()  + b.intValue();
+        }
+
+        throw new UnsupportedOperationException(a.getClass() + " + " + b.getClass() + " is not supported");
+    }
 }

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenerator.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenerator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.data.table.autogen;
+
+import com.twosigma.webtau.data.table.Record;
+
+public class TableDataCellValueGenerator<R> {
+    private TableDataCellValueGenFullFunction<R> genFunction;
+    private TableDataCellValueGenOnlyRecordFunction<R> genOnlyRecordFunction;
+
+    public TableDataCellValueGenerator(TableDataCellValueGenFullFunction<R> genFunction) {
+        this.genFunction = genFunction;
+    }
+
+    public TableDataCellValueGenerator(TableDataCellValueGenOnlyRecordFunction<R> genOnlyRecordFunction) {
+        this.genOnlyRecordFunction = genOnlyRecordFunction;
+    }
+
+    public Object generate(Record row, Record prev, int rowIdx, int colIdx, String columnName) {
+        if (genOnlyRecordFunction != null) {
+            return genOnlyRecordFunction.apply(row);
+        } else {
+            return genFunction.apply(row, prev, rowIdx, colIdx, columnName);
+        }
+    }
+}

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/TableDataTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/TableDataTest.groovy
@@ -82,9 +82,9 @@ class TableDataTest {
 
     static TableData createTableDataWithPermute() {
         table("Col A"              , "Col B"         , "Col C",
-                ________________________________________________________________,
-                permute(true, false), "v1b"           , permute('a', 'b'),
-                "v2a"               , permute(10, 20) , "v2c")
+               ________________________________________________________________,
+               permute(true, false), "v1b"           , permute('a', 'b'),
+               "v2a"               , permute(10, 20) , "v2c")
     }
 
     static TableData createTableDataWithPreviousRef() {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/TableDataTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/TableDataTest.groovy
@@ -42,7 +42,7 @@ class TableDataTest {
         assert tableData.row(1).toMap() == ["Col A": "v2a", "Col B": "v2b", "Col C": 10]
         assert tableData.row(2).toMap() == ["Col A": "v2a", "Col B": "v2b", "Col C": 20]
 
-        DocumentationArtifacts.create(TableDataTest, 'table-with-cell-previous.json', tableData.toJson())
+        DocumentationArtifacts.create(TableDataTest, 'table-with-cell-above.json', tableData.toJson())
     }
 
     @Test(expected = IllegalArgumentException)
@@ -91,8 +91,8 @@ class TableDataTest {
         table("Col A", "Col B", "Col C",
               ________________________________________________,
                 "v1a",   "v1b", 10,
-                "v2a",   "v2b", cell.previous,
-                "v2a",   "v2b", cell.previous.plus(10))
+                "v2a",   "v2b", cell.above,
+                "v2a",   "v2b", cell.above.plus(10))
     }
 
     private static void validateTableData(TableData tableData) {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/TableDataTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/TableDataTest.groovy
@@ -33,6 +33,14 @@ class TableDataTest {
         validateTableData(tableData)
     }
 
+    @Test
+    void "cell previous should be substituted with value from a previous row"() {
+        def tableData = createTableDataWithPreviousRef()
+        assert tableData.numberOfRows() == 2
+        assert tableData.row(0).toMap() == ["Col A": "v1a", "Col B": "v1b", "Col C": "v1c"]
+        assert tableData.row(1).toMap() == ["Col A": "v2a", "Col B": "v2b", "Col C": "v1c"]
+    }
+
     @Test(expected = IllegalArgumentException)
     void "should report columns number mismatch during table creation using header and values vararg methods"() {
         table("Col A", "Col B", "Col C").values(
@@ -51,6 +59,13 @@ class TableDataTest {
               ________________________________,
                 "v1a",   "v1b", "v1c",
                 "v2a",   "v2b", "v2c")
+    }
+
+    static TableData createTableDataWithPreviousRef() {
+        table("Col A", "Col B", "Col C",
+              ________________________________,
+                "v1a",   "v1b", "v1c",
+                "v2a",   "v2b", cell.previous)
     }
 
     private static void validateTableData(TableData tableData) {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/TableDataTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/TableDataTest.groovy
@@ -37,9 +37,12 @@ class TableDataTest {
     @Test
     void "cell previous should be substituted with value from a previous row"() {
         def tableData = createTableDataWithPreviousRef()
-        assert tableData.numberOfRows() == 2
-        assert tableData.row(0).toMap() == ["Col A": "v1a", "Col B": "v1b", "Col C": "v1c"]
-        assert tableData.row(1).toMap() == ["Col A": "v2a", "Col B": "v2b", "Col C": "v1c"]
+        assert tableData.numberOfRows() == 3
+        assert tableData.row(0).toMap() == ["Col A": "v1a", "Col B": "v1b", "Col C": 10]
+        assert tableData.row(1).toMap() == ["Col A": "v2a", "Col B": "v2b", "Col C": 10]
+        assert tableData.row(2).toMap() == ["Col A": "v2a", "Col B": "v2b", "Col C": 20]
+
+        DocumentationArtifacts.create(TableDataTest, 'table-with-cell-previous.json', tableData.toJson())
     }
 
     @Test(expected = IllegalArgumentException)
@@ -86,9 +89,10 @@ class TableDataTest {
 
     static TableData createTableDataWithPreviousRef() {
         table("Col A", "Col B", "Col C",
-              ________________________________,
-                "v1a",   "v1b", "v1c",
-                "v2a",   "v2b", cell.previous)
+              ________________________________________________,
+                "v1a",   "v1b", 10,
+                "v2a",   "v2b", cell.previous,
+                "v2a",   "v2b", cell.previous.plus(10))
     }
 
     private static void validateTableData(TableData tableData) {

--- a/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaSyntaxTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaSyntaxTest.java
@@ -16,13 +16,20 @@
 
 package com.twosigma.webtau.data.table;
 
-import static com.twosigma.webtau.Ddjt.cellValue;
-import static com.twosigma.webtau.Ddjt.table;
+import org.junit.Test;
 
-public class TableDataJavaTest {
-    static TableData createTableDataWithAccessToPrevious() {
-        return table("Col A", "Col B", "Col C").values(
-                       "v1a",   "v1b", cellValue((record) -> record.get("Col A")),
-                       "v2a",   "v2b", 50);
+import static com.twosigma.webtau.Ddjt.*;
+
+public class TableDataJavaSyntaxTest {
+    @Test
+    public void makingSureJavaCodeCompiles() {
+        actual(createTableDataWithAccessToPrevious().numberOfRows()).should(equal(2));
+    }
+
+    private static TableData createTableDataWithAccessToPrevious() {
+        return table("Col A", "Col B", "Col C",
+                    ________________________________,
+                       "v1a",   "v1b", 10,
+                       "v2a",   "v2b", cell.previous);
     }
 }

--- a/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaSyntaxTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaSyntaxTest.java
@@ -16,6 +16,7 @@
 
 package com.twosigma.webtau.data.table;
 
+import com.twosigma.webtau.data.table.autogen.TableDataCellValueGenerator;
 import org.junit.Test;
 
 import static com.twosigma.webtau.Ddjt.*;
@@ -23,13 +24,19 @@ import static com.twosigma.webtau.Ddjt.*;
 public class TableDataJavaSyntaxTest {
     @Test
     public void makingSureJavaCodeCompiles() {
-        actual(createTableDataWithAccessToPrevious().numberOfRows()).should(equal(2));
+        TableData tableData = createTableDataWithAccessToPrevious();
+        actual(tableData.numberOfRows()).should(equal(3));
     }
 
+    // TODO move table data java tests to this test file
+    // mdoc needs to support removal of "return" and semicolon from function body first
     private static TableData createTableDataWithAccessToPrevious() {
+        TableDataCellValueGenerator<?> increment = cell.previous.plus(10);
+
         return table("Col A", "Col B", "Col C",
-                    ________________________________,
+                    ________________________________________________,
                        "v1a",   "v1b", 10,
-                       "v2a",   "v2b", cell.previous);
+                       "v2a",   "v2b", increment,
+                       "v2a",   "v2b", increment);
     }
 }

--- a/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaSyntaxTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaSyntaxTest.java
@@ -31,7 +31,7 @@ public class TableDataJavaSyntaxTest {
     // TODO move table data java tests to this test file
     // mdoc needs to support removal of "return" and semicolon from function body first
     private static TableData createTableDataWithAccessToPrevious() {
-        TableDataCellValueGenerator<?> increment = cell.previous.plus(10);
+        TableDataCellValueGenerator<?> increment = cell.above.plus(10);
 
         return table("Col A", "Col B", "Col C",
                     ________________________________________________,

--- a/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.data.table;
+
+import static com.twosigma.webtau.Ddjt.cellValue;
+import static com.twosigma.webtau.Ddjt.table;
+
+public class TableDataJavaTest {
+    static TableData createTableDataWithAccessToPrevious() {
+        return table("Col A", "Col B", "Col C").values(
+                       "v1a",   "v1b", cellValue((record) -> record.get("Col A")),
+                       "v2a",   "v2b", 50);
+    }
+}

--- a/webtau-docs/webtau/reference/table-data.md
+++ b/webtau-docs/webtau/reference/table-data.md
@@ -49,4 +49,4 @@ Java:
 :include-groovy: com/twosigma/webtau/data/table/TableDataTest.groovy {entry: "createTableDataWithPreviousRef", bodyOnly: true}
 ```
 
-:include-table: table-with-cell-previous.json
+:include-table: table-with-cell-above.json

--- a/webtau-docs/webtau/reference/table-data.md
+++ b/webtau-docs/webtau/reference/table-data.md
@@ -36,3 +36,17 @@ Java:
 ```
 
 :include-table: table-with-permute.json
+
+# Previous Value Reference
+
+Use `cell.previous` to refer to the previous row value
+
+```tabs
+Groovy:
+:include-groovy: com/twosigma/webtau/data/table/TableDataExtensionTest.groovy {entry: "createTableDataWithPreviousRef", bodyOnly: true}
+
+Java:
+:include-groovy: com/twosigma/webtau/data/table/TableDataTest.groovy {entry: "createTableDataWithPreviousRef", bodyOnly: true}
+```
+
+:include-table: table-with-cell-previous.json


### PR DESCRIPTION
Initial functionality to allow the following.
```
["Col A" | "Col B" | "Col C"] {
__________________________________________
   "v1a" |   "v1b" | 10
   "v2a" |   "v2b" | cell.above
   "v2a" |   "v2b" | cell.above + 10 }
```

It is not feature complete yet but want us to settle on names and approach.  
Most likely `__` shortcut will be added to mean the same as `cell.above`