### PR TITLE
Undeclared throwable

### DIFF
--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/code/ThrowExceptionMatcher.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/code/ThrowExceptionMatcher.java
@@ -16,13 +16,13 @@
 
 package com.twosigma.webtau.expectation.code;
 
+import static com.twosigma.webtau.Ddjt.createActualPath;
+
 import com.twosigma.webtau.expectation.CodeBlock;
 import com.twosigma.webtau.expectation.CodeMatcher;
 import com.twosigma.webtau.expectation.equality.CompareToComparator;
-
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.regex.Pattern;
-
-import static com.twosigma.webtau.Ddjt.createActualPath;
 
 public class ThrowExceptionMatcher implements CodeMatcher {
     private String expectedMessage;
@@ -74,8 +74,7 @@ public class ThrowExceptionMatcher implements CodeMatcher {
         try {
             codeBlock.execute();
         } catch (Throwable t) {
-            thrownMessage = t.getMessage();
-            thrownClass = t.getClass();
+            extractExceptionDetails(t);
         }
 
         comparator = CompareToComparator.comparator();
@@ -97,5 +96,16 @@ public class ThrowExceptionMatcher implements CodeMatcher {
         }
 
         return isEqual;
+    }
+
+    private void extractExceptionDetails(Throwable t) {
+        if (t instanceof UndeclaredThrowableException) {
+            Throwable undeclaredCheckedException = t.getCause();
+            thrownMessage = undeclaredCheckedException.getMessage();
+            thrownClass = undeclaredCheckedException.getClass();
+        } else {
+            thrownMessage = t.getMessage();
+            thrownClass = t.getClass();
+        }
     }
 }

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/code/ThrowExceptionMatcherGroovyTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/code/ThrowExceptionMatcherGroovyTest.groovy
@@ -20,6 +20,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 
+import java.lang.reflect.UndeclaredThrowableException
+
 import static com.twosigma.webtau.Ddjt.code
 import static com.twosigma.webtau.Ddjt.throwException
 
@@ -119,9 +121,20 @@ class ThrowExceptionMatcherGroovyTest {
         } should throwException(IllegalArgumentException)
     }
 
+    @Test
+    void "handle undeclared throwable exceptions"() {
+        code { checkedExceptionThrowingProxy('catch me if you can') }
+                .should(throwException(IOException, 'catch me if you can'))
+    }
+
+
     private static businessLogic(num) {
         if (num < 0) {
             throw new IllegalArgumentException('negative not allowed')
         }
+    }
+
+    private static checkedExceptionThrowingProxy(def message) {
+        throw new UndeclaredThrowableException(new IOException(message))
     }
 }

--- a/webtau-docs/webtau/generic-runners/JUnit-5.md
+++ b/webtau-docs/webtau/generic-runners/JUnit-5.md
@@ -12,8 +12,7 @@ Java: :include-file: com/example/tests/junit5/CustomerCrudSeparatedJavaTest.java
 
 :include-file: maven/junit5-dep.xml
 
-# Specific Features
-## TestFactory
+# TestFactory
 
 With the additional annotation `@TestFactory` you can use `TableData` as an easy-to-read source of 
 similar but independent tests where each row is treated as its own test (comparable to JUnit 4's 

--- a/webtau-docs/webtau/generic-runners/JUnit-5.md
+++ b/webtau-docs/webtau/generic-runners/JUnit-5.md
@@ -11,3 +11,16 @@ Java: :include-file: com/example/tests/junit5/CustomerCrudSeparatedJavaTest.java
 # Maven Import
 
 :include-file: maven/junit5-dep.xml
+
+# Specific Features
+## TestFactory
+
+With the additional annotation `@TestFactory` you can use `TableData` as an easy-to-read source of 
+similar but independent tests where each row is treated as its own test (comparable to JUnit 4's 
+parameterized tests), optionally with a descriptive label. 
+Here are examples of parameterized tests with and without labels, and how an IDE uses the label for display purposes:
+:include-groovy: com/example/tests/junit5/DynamicTestsGroovyTest.groovy {title: "Parameterized tests without explicit label", entry: "individual tests use generated display labels"}
+
+:include-groovy: com/example/tests/junit5/DynamicTestsGroovyTest.groovy {title: "Parameterized tests with explicit label", entry: "individual tests can use an optional display label to clarify the use case"}
+
+:include-image: img/intellij-parameterized-tests.png

--- a/webtau-docs/webtau/groovy-specific-runner/data-driven-scenarios.md
+++ b/webtau-docs/webtau/groovy-specific-runner/data-driven-scenarios.md
@@ -18,15 +18,3 @@ Use `data.csv` to conveniently build your scenarios from an external `CSV` data 
 Use `TableData` if you want to derive data and/or have a convenience of collocating data and tests 
 
 :include-file: scenarios/concept/dataDrivenTableData.groovy {title: "TableData-driven tests"}
-
-## TestFactory
-
-With the additional annotation `@TestFactory` you can use `TableData` as an easy-to-read source of 
-similar but independent tests where each row is treated as its own test (comparable to JUnit's 
-parameterized tests), optionally with a descriptive label. 
-Here are examples of parameterized tests with and without labels, and how an IDE uses the label for display purposes:
-:include-groovy: com/example/tests/junit5/DynamicTestsGroovyTest.groovy {title: "Parameterized tests without explicit label", entry: "individual tests use generated display labels"}
-
-:include-groovy: com/example/tests/junit5/DynamicTestsGroovyTest.groovy {title: "Parameterized tests with explicit label", entry: "individual tests can use an optional display label to clarify the use case"}
-
-:include-image: img/intellij-parameterized-tests.png


### PR DESCRIPTION
Some code flows involve a proxy that wrap checked exceptions in an UndeclaredThrowableException (see https://docs.oracle.com/javase/8/docs/api/index.html?java/lang/reflect/UndeclaredThrowableException.html) .
In this case, we still need to extract the wrapped exception class and message.