### PR TITLE
Send user agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -610,6 +610,19 @@
                     </dependency>
                 </dependencies>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/ConfigValue.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/ConfigValue.java
@@ -158,6 +158,10 @@ public class ConfigValue {
         return ! isDefault();
     }
 
+    public Object getDefaultValue() {
+        return defaultValueSupplier.get();
+    }
+
     private String convertToString(Object value) {
         return value == null ? "" : value.toString();
     }

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
@@ -47,7 +47,10 @@ public class WebTauConfig {
     private final ConfigValue disableFollowingRedirects = declareBoolean("disableRedirects", "disable following of redirects from HTTP calls");
     private final ConfigValue maxRedirects = declare("maxRedirects", "Maximum number of redirects to follow for an HTTP call", () -> 20);
     private final ConfigValue userAgent = declare("userAgent", "User agent to send on HTTP requests",
-            () -> "webtau/"+getClass().getPackage().getImplementationVersion());
+            () -> "webtau/" + getClass().getPackage().getImplementationVersion());
+    private final ConfigValue removeWebtauFromUserAgent = declare("removeWebtauFromUserAgent",
+            "By default webtau appends webtau and its version to the user-agent, this disables that part",
+            () -> false);
     private final ConfigValue workingDir = declare("workingDir", "logical working dir", () -> Paths.get(""));
     private final ConfigValue cachePath = declare("cachePath", "user driven cache file path",
             () -> workingDir.getAsPath().resolve(".webtau.cache.json"));
@@ -187,12 +190,21 @@ public class WebTauConfig {
             return userAgent.getAsString();
         }
 
-        String defaultValue = userAgent.getDefaultValue().toString();
-        return userAgent.getAsString() + "/" + defaultValue;
+        String finalUserAgent = userAgent.getAsString();
+        if (!removeWebtauFromUserAgent.getAsBoolean()) {
+            String defaultValue = userAgent.getDefaultValue().toString();
+            finalUserAgent += " (" + defaultValue + ")";
+        }
+
+        return finalUserAgent;
     }
 
     public ConfigValue getUserAgentConfigValue() {
         return userAgent;
+    }
+
+    public ConfigValue getRemoveWebtauFromUserAgent() {
+        return removeWebtauFromUserAgent;
     }
 
     public Path getDocArtifactsPath() {
@@ -334,6 +346,7 @@ public class WebTauConfig {
                 disableFollowingRedirects,
                 maxRedirects,
                 userAgent,
+                removeWebtauFromUserAgent,
                 docPath,
                 reportPath,
                 noColor,

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
@@ -46,6 +46,8 @@ public class WebTauConfig {
     private final ConfigValue waitTimeout = declare("waitTimeout", "wait timeout in milliseconds", () -> 5000);
     private final ConfigValue disableFollowingRedirects = declareBoolean("disableRedirects", "disable following of redirects from HTTP calls");
     private final ConfigValue maxRedirects = declare("maxRedirects", "Maximum number of redirects to follow for an HTTP call", () -> 20);
+    private final ConfigValue userAgent = declare("userAgent", "User agent to send on HTTP requests",
+            () -> "webtau/"+getClass().getPackage().getImplementationVersion());
     private final ConfigValue workingDir = declare("workingDir", "logical working dir", () -> Paths.get(""));
     private final ConfigValue cachePath = declare("cachePath", "user driven cache file path",
             () -> workingDir.getAsPath().resolve(".webtau.cache.json"));
@@ -178,6 +180,19 @@ public class WebTauConfig {
 
     public int maxRedirects() {
         return maxRedirects.getAsInt();
+    }
+
+    public String getUserAgent() {
+        if (userAgent.isDefault()) {
+            return userAgent.getAsString();
+        }
+
+        String defaultValue = userAgent.getDefaultValue().toString();
+        return userAgent.getAsString() + "/" + defaultValue;
+    }
+
+    public ConfigValue getUserAgentConfigValue() {
+        return userAgent;
     }
 
     public Path getDocArtifactsPath() {
@@ -318,6 +333,7 @@ public class WebTauConfig {
                 waitTimeout,
                 disableFollowingRedirects,
                 maxRedirects,
+                userAgent,
                 docPath,
                 reportPath,
                 noColor,

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -253,10 +253,25 @@ class HttpGroovyTest implements HttpConfiguration {
             cfg.userAgentConfigValue.set("test", "custom")
 
             http.get('/echo-header') {
-                body['User-Agent'].should == ~/^custom\/webtau\//
+                body['User-Agent'].should == ~/^custom \(webtau\/.*\)$/
             }
         } finally {
             cfg.userAgentConfigValue.reset()
+        }
+    }
+
+    @Test
+    void "custom user agent without webtau and its version"() {
+        try {
+            cfg.userAgentConfigValue.set("test", "custom")
+            cfg.removeWebtauFromUserAgent.set("true", true)
+
+            http.get('/echo-header') {
+                body['User-Agent'].should == ~/^custom$/
+            }
+        } finally {
+            cfg.userAgentConfigValue.reset()
+            cfg.removeWebtauFromUserAgent.reset()
         }
     }
 

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -37,6 +37,7 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 
 import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.cfg.WebTauConfig.cfg
 import static com.twosigma.webtau.http.Http.*
 import static org.junit.Assert.*
 
@@ -237,6 +238,26 @@ class HttpGroovyTest implements HttpConfiguration {
             'param2': 'value2'])
 
         assert varArgQuery == mapBasedQuery
+    }
+
+    @Test
+    void "default user agent"() {
+        http.get('/echo-header') {
+            body['User-Agent'].should == ~/^webtau\//
+        }
+    }
+
+    @Test
+    void "custom user agent"() {
+        try {
+            cfg.userAgentConfigValue.set("test", "custom")
+
+            http.get('/echo-header') {
+                body['User-Agent'].should == ~/^custom\/webtau\//
+            }
+        } finally {
+            cfg.userAgentConfigValue.reset()
+        }
     }
 
     @Test

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
@@ -575,6 +575,7 @@ public class Http {
             connection.setRequestMethod(method);
             connection.setRequestProperty("Content-Type", requestBody.type());
             connection.setRequestProperty("Accept", requestBody.type());
+            connection.setRequestProperty("User-Agent", getCfg().getUserAgent());
             requestHeader.forEachProperty(connection::setRequestProperty);
 
             if (! (requestBody instanceof EmptyRequestBody)) {


### PR DESCRIPTION
Closes #329 

Default behaviour is to send `webtau/<version>`.  If a user agent is specified in cfg, we send `<cfg-user-agent> (webtau/<version>)`.  It is also possible to not append the `(webtau/<version>)` bit with a custom agent by specifying an appropriate cfg option.