### PR TITLE
Adding with method to HttpHeader

### DIFF
--- a/webtau-http/src/main/java/com/twosigma/webtau/http/HttpHeader.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/HttpHeader.java
@@ -78,6 +78,13 @@ public class HttpHeader {
         header.put(key, value);
     }
 
+    public HttpHeader with(String key, String value) {
+        Map<String, String> copy = new LinkedHashMap<>(this.header);
+        copy.put(key, value);
+
+        return new HttpHeader(copy);
+    }
+
     public HttpHeader redactSecrets() {
         Map<String, String> redacted = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : header.entrySet()) {

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/HttpHeader.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/HttpHeader.java
@@ -16,6 +16,8 @@
 
 package com.twosigma.webtau.http;
 
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -74,6 +76,20 @@ public class HttpHeader {
                 .orElse(null);
     }
 
+    /**
+     * Adds an addition header to this HttpHeader object.  This function
+     * may throw UnsupportedOperationException depending on how HttpHeader
+     * was constructed.
+     *
+     * For that reason, this method is deprecated and you should use either
+     * <code>with(String key, String value)</code> or one of the <code>merge</code>
+     * methods which are non-mutating.
+     *
+     * @deprecated use <code>with(String key, String value)</code>
+     *             or <code>merge(HttpHeader otherHeader)</code>
+     *             or <code>merge(Map&lt;String, String&gt; properties)</code>
+     */
+    @Deprecated
     public void add(String key, String value) {
         header.put(key, value);
     }

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/HttpResponse.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/HttpResponse.java
@@ -98,7 +98,7 @@ public class HttpResponse {
     }
 
     public void addHeader(String key, String value) {
-        header.add(key, value);
+        header = header.with(key, value);
     }
 
     public boolean isRedirect() {

--- a/webtau-http/src/test/groovy/com/twosigma/webtau/http/HttpHeaderTest.groovy
+++ b/webtau-http/src/test/groovy/com/twosigma/webtau/http/HttpHeaderTest.groovy
@@ -81,4 +81,11 @@ class HttpHeaderTest {
             'other': 'value'
         ])
     }
+
+    @Test
+    void "build from empty header"() {
+        def header = HttpHeader.EMPTY
+        def newHeader = header.with('foo', 'bar')
+        newHeader.should == new HttpHeader(['foo': 'bar'])
+    }
 }


### PR DESCRIPTION
Closes #332 

We can't really change the `add` method into a non-mutating version as it might break people.  Therefore, I've deprecated it and added a non-mutating `with`.