### PR TITLE
add query param overloads for post requests

### DIFF
--- a/webtau-http-groovy/src/main/groovy/com/twosigma/webtau/http/HttpExtensions.groovy
+++ b/webtau-http-groovy/src/main/groovy/com/twosigma/webtau/http/HttpExtensions.groovy
@@ -49,28 +49,56 @@ class HttpExtensions {
         return http.get(url, queryParams, closureToHttpResponseValidator(validation))
     }
 
+    static def post(Http http, String url, HttpQueryParams queryParams, HttpHeader header, Map<String, Object> requestBody, Closure validation) {
+        return http.post(url, queryParams, header, new JsonRequestBody(requestBody), closureToHttpResponseValidator(validation))
+    }
+
     static def post(Http http, String url, HttpHeader header, Map<String, Object> requestBody, Closure validation) {
         return http.post(url, header, new JsonRequestBody(requestBody), closureToHttpResponseValidator(validation))
+    }
+
+    static def post(Http http, String url, HttpQueryParams queryParams, Map<String, Object> requestBody, Closure validation) {
+        return http.post(url, queryParams, new JsonRequestBody(requestBody), closureToHttpResponseValidator(validation))
     }
 
     static def post(Http http, String url, Map<String, Object> requestBody, Closure validation) {
         return http.post(url, new JsonRequestBody(requestBody), closureToHttpResponseValidator(validation))
     }
 
+    static def post(Http http, String url, HttpQueryParams queryParams, Closure validation) {
+        return http.post(url, queryParams, closureToHttpResponseValidator(validation))
+    }
+
     static def post(Http http, String url, Closure validation) {
         return http.post(url, closureToHttpResponseValidator(validation))
+    }
+
+    static def post(Http http, String url, HttpQueryParams queryParams, HttpHeader header, Closure validation) {
+        return http.post(url, queryParams, header, closureToHttpResponseValidator(validation))
     }
 
     static def post(Http http, String url, HttpHeader header, Closure validation) {
         return http.post(url, header, closureToHttpResponseValidator(validation))
     }
 
+    static def post(Http http, String url, HttpQueryParams queryParams, HttpHeader header, HttpRequestBody requestBody, Closure validation) {
+        return http.post(url, queryParams, header, requestBody, closureToHttpResponseValidator(validation))
+    }
+
     static def post(Http http, String url, HttpHeader header, HttpRequestBody requestBody, Closure validation) {
         return http.post(url, header, requestBody, closureToHttpResponseValidator(validation))
     }
 
+    static def post(Http http, String url, HttpQueryParams queryParams, HttpRequestBody requestBody, Closure validation) {
+        return http.post(url, queryParams, requestBody, closureToHttpResponseValidator(validation))
+    }
+
     static def post(Http http, String url, HttpRequestBody requestBody, Closure validation) {
         return http.post(url, requestBody, closureToHttpResponseValidator(validation))
+    }
+
+    static void post(Http http, String url, HttpQueryParams queryParams, Map<String, Object> requestBody) {
+        http.post(url, queryParams, new JsonRequestBody(requestBody))
     }
 
     static void post(Http http, String url, Map<String, Object> requestBody) {

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -240,6 +240,14 @@ class HttpGroovyTest implements HttpConfiguration {
     }
 
     @Test
+    void "post with query params"() {
+        http.post("params", http.query('a', '1', 'b', 'text')) {
+            a.should == 1
+            b.should == 'text'
+        }
+    }
+
+    @Test
     void "explicitly access header and body "() {
         def a = http.get("params", [a: 1, b: 'text']) { header, body ->
             return body.a

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
@@ -111,64 +111,124 @@ public class Http {
         get(url, HttpQueryParams.EMPTY, HttpHeader.EMPTY, new HttpResponseValidatorIgnoringReturn(validator));
     }
 
-    public <E> E post(String url, HttpHeader header, HttpRequestBody requestBody, HttpResponseValidatorWithReturn validator) {
-        return executeAndValidateHttpCall("POST", url,
+    public <E> E post(String url, HttpQueryParams queryParams, HttpHeader header, HttpRequestBody requestBody, HttpResponseValidatorWithReturn validator) {
+        return executeAndValidateHttpCall("POST", queryParams.attachToUrl(url),
                 (fullUrl, fullHeader) -> postToFullUrl(fullUrl, fullHeader, requestBody),
                 header,
                 requestBody,
                 validator);
     }
 
+    public <E> E post(String url, HttpHeader header, HttpRequestBody requestBody, HttpResponseValidatorWithReturn validator) {
+        return post(url, HttpQueryParams.EMPTY, header, requestBody, validator);
+    }
+
+    public void post(String url, HttpQueryParams queryParams, HttpHeader header, HttpRequestBody requestBody, HttpResponseValidator validator) {
+        post(url, queryParams, header, requestBody, new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
     public void post(String url, HttpHeader header, HttpRequestBody requestBody, HttpResponseValidator validator) {
         post(url, header, requestBody, new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
+    public <E> E post(String url, HttpQueryParams queryParams, HttpHeader header, HttpResponseValidatorWithReturn validator) {
+        return post(url, queryParams, header, EmptyRequestBody.INSTANCE, validator);
     }
 
     public <E> E post(String url, HttpHeader header, HttpResponseValidatorWithReturn validator) {
         return post(url, header, EmptyRequestBody.INSTANCE, validator);
     }
 
+    public void post(String url, HttpQueryParams queryParams, HttpHeader header, HttpResponseValidator validator) {
+        post(url, queryParams, header, EmptyRequestBody.INSTANCE, new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
     public void post(String url, HttpHeader header, HttpResponseValidator validator) {
         post(url, header, EmptyRequestBody.INSTANCE, new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
+    public <E> E post(String url, HttpQueryParams queryParams, HttpRequestBody requestBody, HttpResponseValidatorWithReturn validator) {
+        return post(url, queryParams, HttpHeader.EMPTY, requestBody, validator);
     }
 
     public <E> E post(String url, HttpRequestBody requestBody, HttpResponseValidatorWithReturn validator) {
         return post(url, HttpHeader.EMPTY, requestBody, validator);
     }
 
+    public void post(String url, HttpQueryParams queryParams, HttpRequestBody requestBody, HttpResponseValidator validator) {
+        post(url, queryParams, requestBody, new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
     public void post(String url, HttpRequestBody requestBody, HttpResponseValidator validator) {
         post(url, requestBody, new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
+    public <E> E post(String url, HttpQueryParams queryParams, HttpHeader header, Map<String, Object> requestBody, HttpResponseValidatorWithReturn validator) {
+        return post(url, queryParams, header, new JsonRequestBody(requestBody), validator);
     }
 
     public <E> E post(String url, HttpHeader header, Map<String, Object> requestBody, HttpResponseValidatorWithReturn validator) {
         return post(url, header, new JsonRequestBody(requestBody), validator);
     }
 
+    public void post(String url, HttpQueryParams queryParams, HttpHeader header, Map<String, Object> requestBody, HttpResponseValidator validator) {
+        post(url, queryParams, header, new JsonRequestBody(requestBody), new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
     public void post(String url, HttpHeader header, Map<String, Object> requestBody, HttpResponseValidator validator) {
         post(url, header, new JsonRequestBody(requestBody), new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
+    public <E> E post(String url, HttpQueryParams queryParams, Map<String, Object> requestBody, HttpResponseValidatorWithReturn validator) {
+        return post(url, queryParams, HttpHeader.EMPTY, new JsonRequestBody(requestBody), validator);
     }
 
     public <E> E post(String url, Map<String, Object> requestBody, HttpResponseValidatorWithReturn validator) {
         return post(url, HttpHeader.EMPTY, new JsonRequestBody(requestBody), validator);
     }
 
+    public void post(String url, HttpQueryParams queryParams, Map<String, Object> requestBody, HttpResponseValidator validator) {
+        post(url, queryParams, HttpHeader.EMPTY, new JsonRequestBody(requestBody), new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
     public void post(String url, Map<String, Object> requestBody, HttpResponseValidator validator) {
         post(url, HttpHeader.EMPTY, new JsonRequestBody(requestBody), new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
+    public <E> E post(String url, HttpQueryParams queryParams, HttpResponseValidatorWithReturn validator) {
+        return post(url, queryParams, EmptyRequestBody.INSTANCE, validator);
     }
 
     public <E> E post(String url, HttpResponseValidatorWithReturn validator) {
         return post(url, EmptyRequestBody.INSTANCE, validator);
     }
 
+    public void post(String url, HttpQueryParams queryParams, HttpResponseValidator validator) {
+        post(url, queryParams, EmptyRequestBody.INSTANCE, new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
     public void post(String url, HttpResponseValidator validator) {
         post(url, EmptyRequestBody.INSTANCE, new HttpResponseValidatorIgnoringReturn(validator));
+    }
+
+    public void post(String url, HttpQueryParams queryParams, HttpHeader header) {
+        post(url, queryParams, header, EMPTY_RESPONSE_VALIDATOR);
     }
 
     public void post(String url, HttpHeader header) {
         post(url, header, EMPTY_RESPONSE_VALIDATOR);
     }
 
+    public void post(String url, HttpQueryParams queryParams) {
+        post(url, queryParams, EMPTY_RESPONSE_VALIDATOR);
+    }
+
     public void post(String url) {
         post(url, EMPTY_RESPONSE_VALIDATOR);
+    }
+
+    public void post(String url, HttpQueryParams queryParams, HttpRequestBody requestBody) {
+        post(url, queryParams, requestBody, EMPTY_RESPONSE_VALIDATOR);
     }
 
     public void post(String url, HttpRequestBody requestBody) {

--- a/webtau-http/src/test/java/com/twosigma/webtau/http/HttpTestDataServer.java
+++ b/webtau-http/src/test/java/com/twosigma/webtau/http/HttpTestDataServer.java
@@ -66,6 +66,7 @@ public class HttpTestDataServer {
         testServer.registerPost("/file-upload", new TestServerFakeFileUpload());
         testServer.registerDelete("/resource", new TestServerTextResponse("abc"));
         testServer.registerGet("/params?a=1&b=text", new TestServerJsonResponse("{\"a\": 1, \"b\": \"text\"}"));
+        testServer.registerPost("/params?a=1&b=text", new TestServerJsonResponse("{\"a\": 1, \"b\": \"text\"}", 201));
 
         registerRedirects();
     }


### PR DESCRIPTION
closes #327 

PUT and DELETE don't support query params but this was so tedious for POST alone that I decided not to tackle PUT and DELETE yet, have raised issues for those: #335 and #336