### PR TITLE
Report status code before schema

### DIFF
--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
@@ -47,7 +47,7 @@ public class WebTauConfig {
     private final ConfigValue disableFollowingRedirects = declareBoolean("disableRedirects", "disable following of redirects from HTTP calls");
     private final ConfigValue maxRedirects = declare("maxRedirects", "Maximum number of redirects to follow for an HTTP call", () -> 20);
     private final ConfigValue userAgent = declare("userAgent", "User agent to send on HTTP requests",
-            () -> "webtau/" + getClass().getPackage().getImplementationVersion());
+            () -> "webtau/" + WebTauMeta.getVersion());
     private final ConfigValue removeWebtauFromUserAgent = declare("removeWebtauFromUserAgent",
             "By default webtau appends webtau and its version to the user-agent, this disables that part",
             () -> false);

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauMeta.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauMeta.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package com.twosigma.webtau.meta;
-
-import com.twosigma.webtau.utils.ResourceUtils;
+package com.twosigma.webtau.cfg;
 
 public class WebTauMeta {
     private static final WebTauMeta INSTANCE = new WebTauMeta();
@@ -27,6 +25,6 @@ public class WebTauMeta {
     }
 
     private WebTauMeta() {
-        version = ResourceUtils.textContent("webtau.version").trim();
+        version = getClass().getPackage().getImplementationVersion();
     }
 }

--- a/webtau-core/pom.xml
+++ b/webtau-core/pom.xml
@@ -53,13 +53,6 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
-
         <plugins>
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>

--- a/webtau-core/src/main/resources/webtau.version
+++ b/webtau-core/src/main/resources/webtau.version
@@ -1,1 +1,0 @@
-${project.version}

--- a/webtau-feature-testing/examples/scenarios/rest/openapi/api-spec.json
+++ b/webtau-feature-testing/examples/scenarios/rest/openapi/api-spec.json
@@ -44,13 +44,13 @@
           "200": {
             "description": "customer already exists",
             "schema": {
-              "$ref": "#/definitions/Employee"
+              "$ref": "#/definitions/Id"
             }
           },
           "201": {
             "description": "customer created successfully",
             "schema": {
-              "$ref": "#/definitions/Employee"
+              "$ref": "#/definitions/Id"
             }
           }
         }
@@ -69,6 +69,17 @@
           "type": "string"
         },
         "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "Id": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
           "type": "string"
         }
       }

--- a/webtau-feature-testing/test-expectations/scenarios/rest/openapi/disableOpenApiValidation/run-details.json
+++ b/webtau-feature-testing/test-expectations/scenarios/rest/openapi/disableOpenApiValidation/run-details.json
@@ -7,7 +7,7 @@
   }, {
     "scenario" : "disable request validation",
     "stepsSummary" : {
-      "numberOfFailed" : 2
+      "numberOfSuccessful" : 3
     }
   }, {
     "scenario" : "disable response validation",
@@ -15,5 +15,5 @@
       "numberOfSuccessful" : 3
     }
   } ],
-  "exitCode" : 1
+  "exitCode" : 0
 }

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
@@ -16,7 +16,6 @@
 
 package com.twosigma.webtau.cfg
 
-import com.twosigma.webtau.meta.WebTauMeta
 import org.apache.commons.cli.CommandLine
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.HelpFormatter

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -23,6 +23,7 @@ import com.twosigma.webtau.http.datanode.DataNode
 import com.twosigma.webtau.http.datanode.GroovyDataNode
 import com.twosigma.webtau.http.testserver.TestServerResponse
 import com.twosigma.webtau.http.validation.HttpResponseValidator
+import com.twosigma.webtau.http.validation.HttpValidationHandlers
 import com.twosigma.webtau.utils.ResourceUtils
 import com.twosigma.webtau.utils.UrlUtils
 import org.junit.*
@@ -980,6 +981,18 @@ class HttpGroovyTest implements HttpConfiguration {
         } should throwException(HttpException, ~/error during http\.get/)
 
         http.lastValidationResult.errorMessage.should == ~/java.lang.IllegalArgumentException: Request header is null/
+    }
+
+    @Test
+    void "status code mismatch reported before additional validators"() {
+        HttpValidationHandlers.register { result -> throw new AssertionError((Object)"schema validation error") }
+        try {
+            code {
+                http.get("/notfound") {}
+            } should throwException(AssertionError, ~/(?s)header.statusCode.*404.*200/)
+        } finally {
+            HttpValidationHandlers.reset()
+        }
     }
 
     @Override

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -984,11 +984,39 @@ class HttpGroovyTest implements HttpConfiguration {
     }
 
     @Test
-    void "status code mismatch reported before additional validators"() {
+    void "implicit status code mismatch reported before additional validators"() {
         HttpValidationHandlers.register { result -> throw new AssertionError((Object)"schema validation error") }
         try {
             code {
                 http.get("/notfound") {}
+            } should throwException(AssertionError, ~/(?s)header.statusCode.*404.*200/)
+        } finally {
+            HttpValidationHandlers.reset()
+        }
+    }
+
+    @Test
+    void "explicit status code mismatch reported before additional validators"() {
+        HttpValidationHandlers.register { result -> throw new AssertionError((Object)"schema validation error") }
+        try {
+            code {
+                http.get("/notfound") {
+                    statusCode.should == 200
+                }
+            } should throwException(AssertionError, ~/(?s)header.statusCode.*404.*200/)
+        } finally {
+            HttpValidationHandlers.reset()
+        }
+    }
+
+    @Test
+    void "status code mismatch reported before additional validators and failing body assertions"() {
+        HttpValidationHandlers.register { result -> throw new AssertionError((Object)"schema validation error") }
+        try {
+            code {
+                http.get("/notfound") {
+                    id.should == 'foo'
+                }
             } should throwException(AssertionError, ~/(?s)header.statusCode.*404.*200/)
         } finally {
             HttpValidationHandlers.reset()

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -989,12 +989,18 @@ class HttpGroovyTest implements HttpConfiguration {
         HttpValidationHandlers.withAdditionalHandler(handler, closure)
     }
 
+    static String expected404 = '\n' +
+        'mismatches:\n' +
+        '\n' +
+        'header.statusCode:   actual: 404 <java.lang.Integer>\n' +
+        '                   expected: 200 <java.lang.Integer>'
+
     @Test
     void "reports implicit status code mismatch instead of additional validator errors"() {
         withFailingHandler {
             code {
                 http.get("/notfound") {}
-            } should throwException(AssertionError, ~/(?s)header.statusCode.*404.*200/)
+            } should throwException(AssertionError, expected404)
         }
     }
 
@@ -1005,7 +1011,7 @@ class HttpGroovyTest implements HttpConfiguration {
                 http.get("/notfound") {
                     statusCode.should == 200
                 }
-            } should throwException(AssertionError, ~/(?s)header.statusCode.*404.*200/)
+            } should throwException(AssertionError, expected404)
         }
     }
 
@@ -1016,7 +1022,7 @@ class HttpGroovyTest implements HttpConfiguration {
                 http.get("/notfound") {
                     id.should == 'foo'
                 }
-            } should throwException(AssertionError, ~/(?s)header.statusCode.*404.*200/)
+            } should throwException(AssertionError, expected404)
         }
     }
 
@@ -1028,7 +1034,11 @@ class HttpGroovyTest implements HttpConfiguration {
                     statusCode.should == 404
                     id.should == 'foo'
                 }
-            } should throwException(AssertionError, ~/expected: "foo"/)
+            } should throwException(AssertionError, '\n' +
+                'mismatches:\n' +
+                '\n' +
+                'body.id:   actual: null\n' +
+                '         expected: "foo" <java.lang.String>')
         }
     }
 
@@ -1039,7 +1049,7 @@ class HttpGroovyTest implements HttpConfiguration {
                 http.get("/notfound") {
                     statusCode.should == 404
                 }
-            } should throwException(AssertionError, ~/schema validation error/)
+            } should throwException(AssertionError, 'schema validation error')
         }
     }
 

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -990,7 +990,7 @@ class HttpGroovyTest implements HttpConfiguration {
     }
 
     @Test
-    void "implicit status code mismatch reported before additional validators"() {
+    void "reports implicit status code mismatch instead of additional validator errors"() {
         withFailingHandler {
             code {
                 http.get("/notfound") {}
@@ -999,7 +999,7 @@ class HttpGroovyTest implements HttpConfiguration {
     }
 
     @Test
-    void "explicit status code mismatch reported before additional validators"() {
+    void "reports explicit status code mismatch instead of additional validator errors"() {
         withFailingHandler {
             code {
                 http.get("/notfound") {
@@ -1010,7 +1010,7 @@ class HttpGroovyTest implements HttpConfiguration {
     }
 
     @Test
-    void "status code mismatch reported before additional validators and failing body assertions"() {
+    void "reports status code mismatch instead of additional validator errors or failing body assertions"() {
         withFailingHandler {
             code {
                 http.get("/notfound") {
@@ -1021,7 +1021,7 @@ class HttpGroovyTest implements HttpConfiguration {
     }
 
     @Test
-    void "assertion and additional validation errors"() {
+    void "reports body assertions instead of additional validation errors"() {
         withFailingHandler() {
             code {
                 http.get("/notfound") {
@@ -1033,7 +1033,7 @@ class HttpGroovyTest implements HttpConfiguration {
     }
 
     @Test
-    void "additional validator errors reported if status code is correct"() {
+    void "reports additional validator errors if status code is correct"() {
         withFailingHandler {
             code {
                 http.get("/notfound") {

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -1023,6 +1023,35 @@ class HttpGroovyTest implements HttpConfiguration {
         }
     }
 
+    @Test
+    void "assertion and additional validation errors"() {
+        HttpValidationHandlers.register { result -> throw new AssertionError((Object)"schema validation error") }
+        try {
+            code {
+                http.get("/notfound") {
+                    statusCode.should == 404
+                    id.should == 'foo'
+                }
+            } should throwException(AssertionError, ~/expected: "foo"/)
+        } finally {
+            HttpValidationHandlers.reset()
+        }
+    }
+
+    @Test
+    void "additional validator errors reported if status code is correct"() {
+        HttpValidationHandlers.register { result -> throw new AssertionError((Object)"schema validation error") }
+        try {
+            code {
+                http.get("/notfound") {
+                    statusCode.should == 404
+                }
+            } should throwException(AssertionError, ~/schema validation error/)
+        } finally {
+            HttpValidationHandlers.reset()
+        }
+    }
+
     @Override
     String fullUrl(String url) {
         if (UrlUtils.isFull(url)) {

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
@@ -436,8 +436,6 @@ public class Http {
         validationResult.setResponseHeaderNode(header);
         validationResult.setResponseBodyNode(body);
 
-        HttpValidationHandlers.validate(validationResult);
-
         ExpectationHandler recordAndThrowHandler = (valueMatcher, actualPath, actualValue, message) -> {
             validationResult.addMismatch(message);
             return ExpectationHandler.Flow.PassToNext;
@@ -457,6 +455,8 @@ public class Http {
                 validateStatusCode(validationResult);
                 return null;
             });
+
+            HttpValidationHandlers.validate(validationResult);
 
             return extracted;
         } catch (Throwable e) {

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/validation/HttpValidationHandlers.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/validation/HttpValidationHandlers.java
@@ -23,6 +23,15 @@ import java.util.List;
 public class HttpValidationHandlers {
     private static final List<HttpValidationHandler> configurations = ServiceLoaderUtils.load(HttpValidationHandler.class);
 
+    public static void register(HttpValidationHandler handler) {
+        configurations.add(handler);
+    }
+
+    public static void reset() {
+        configurations.clear();
+        configurations.addAll(ServiceLoaderUtils.load(HttpValidationHandler.class));
+    }
+
     public static void validate(HttpValidationResult validationResult) {
         configurations.forEach(c -> c.validate(validationResult));
     }

--- a/webtau-report/src/main/java/com/twosigma/webtau/report/HtmlReportGenerator.java
+++ b/webtau-report/src/main/java/com/twosigma/webtau/report/HtmlReportGenerator.java
@@ -17,9 +17,9 @@
 package com.twosigma.webtau.report;
 
 import com.twosigma.webtau.cfg.ConfigValue;
+import com.twosigma.webtau.cfg.WebTauMeta;
 import com.twosigma.webtau.console.ConsoleOutputs;
 import com.twosigma.webtau.console.ansi.Color;
-import com.twosigma.webtau.meta.WebTauMeta;
 import com.twosigma.webtau.utils.FileUtils;
 import com.twosigma.webtau.utils.JsonUtils;
 import com.twosigma.webtau.utils.ResourceUtils;


### PR DESCRIPTION
Closes #302 

Before merging this, I'd like some feedback.  Prior to this PR, any `HttpValidationHandler` errors are reported even if status code fails or user expectations fail.  This is confusing in the case where you expect a request to succeed but it fails and the failure response is of a different schema to what you'd expect; it's confusing because you get a schema validation failure and the fact the request failed is not reported.

We have two options.  The behaviour this PR introduces is to only run `HttpValidationHandlers` if everything else is fine.  So generally you'll get a status code error or user expectation error and only if both of those are fine will you get a schema error.

Do you think it would be better to report in this order:
1. status code mismatch
1. schema failures
1. user expectations

I suspect that's generally better because if the schema is incorrect the odds of the user expectations passing are reduced anyway and could send someone down a rabbit hole.  Unfortunately, this probably requires substantially more refactoring.

Thoughts?