### PR TITLE
initial cli testing frame

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
         <module>webtau-data</module>
         <module>webtau-cache</module>
         <module>webtau-test-server</module>
+        <module>webtau-cli</module>
+        <module>webtau-cli-groovy</module>
         <module>webtau-groovy-ast</module>
         <module>webtau-groovy</module>
         <module>webtau-reactjs</module>

--- a/webtau-cache/pom.xml
+++ b/webtau-cache/pom.xml
@@ -50,6 +50,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <scope>test</scope>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webtau-cli-groovy/pom.xml
+++ b/webtau-cli-groovy/pom.xml
@@ -12,5 +12,17 @@
 
     <artifactId>webtau-cli-groovy</artifactId>
 
-    
+    <dependencies>
+        <dependency>
+            <groupId>com.twosigma.webtau</groupId>
+            <artifactId>webtau-cli</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
 </project>

--- a/webtau-cli-groovy/pom.xml
+++ b/webtau-cli-groovy/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.twosigma.webtau</groupId>
+        <artifactId>webtau-parent</artifactId>
+        <version>1.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>webtau-cli-groovy</artifactId>
+
+    
+</project>

--- a/webtau-cli-groovy/src/main/groovy/com/twosigma/webtau/cli/CliExtension.groovy
+++ b/webtau-cli-groovy/src/main/groovy/com/twosigma/webtau/cli/CliExtension.groovy
@@ -1,0 +1,22 @@
+/*
+ *
+ *  * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.twosigma.webtau.cli
+
+class CliExtension {
+}

--- a/webtau-cli/pom.xml
+++ b/webtau-cli/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.twosigma.webtau</groupId>
+        <artifactId>webtau-parent</artifactId>
+        <version>1.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>webtau-cli</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.twosigma.webtau</groupId>
+            <artifactId>webtau-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <scope>test</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addTestSources</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/webtau-cli/scripts/hello
+++ b/webtau-cli/scripts/hello
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "hello world"

--- a/webtau-cli/scripts/hello
+++ b/webtau-cli/scripts/hello
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo "hello world"
+echo "hello world" $NAME

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/Cli.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/Cli.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli;
+
+import com.twosigma.webtau.cli.expectation.CliExitCode;
+import com.twosigma.webtau.cli.expectation.CliOutput;
+import com.twosigma.webtau.cli.expectation.CliValidationExitCodeOutputHandler;
+import com.twosigma.webtau.cli.expectation.CliValidationOutputOnlylHandler;
+import com.twosigma.webtau.reporter.TestStep;
+
+import java.util.function.Consumer;
+
+import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.action;
+import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.stringValue;
+import static com.twosigma.webtau.reporter.TokenizedMessage.tokenizedMessage;
+
+public class Cli {
+    public static final Cli cli = new Cli();
+
+    private Cli() {
+    }
+
+    public void run(String command, CliValidationOutputOnlylHandler handler) {
+        cliStep(command, (runResult) -> handler.handle(cliOutput(runResult), cliError(runResult)));
+    }
+
+    public void run(String command, CliValidationExitCodeOutputHandler handler) {
+        cliStep(command, (runResult) -> handler.handle(exitCode(runResult), cliOutput(runResult), cliError(runResult)));
+    }
+
+    private void cliStep(String command, Consumer<ProcessRunResult> validationCode) {
+        TestStep.createAndExecuteStep(null,
+                tokenizedMessage(action("running cli command "), stringValue(command)),
+                () -> tokenizedMessage(action("ran cli clommand"), stringValue(command)),
+                () -> {
+                    ProcessRunResult runResult = ProcessUtils.run(command.split("\\s+"));
+                    validationCode.accept(runResult);
+                });
+    }
+
+    private CliExitCode exitCode(ProcessRunResult runResult) {
+        return new CliExitCode(runResult.getExitCode());
+    }
+
+    private static CliOutput cliOutput(ProcessRunResult runResult) {
+        return new CliOutput("out", runResult.getOutput());
+    }
+
+    private static CliOutput cliError(ProcessRunResult runResult) {
+        return new CliOutput("error", runResult.getError());
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/Cli.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/Cli.java
@@ -45,9 +45,17 @@ public class Cli {
     private void cliStep(String command, Consumer<ProcessRunResult> validationCode) {
         TestStep.createAndExecuteStep(null,
                 tokenizedMessage(action("running cli command "), stringValue(command)),
-                () -> tokenizedMessage(action("ran cli clommand"), stringValue(command)),
+                () -> tokenizedMessage(action("ran cli command"), stringValue(command)),
                 () -> {
                     ProcessRunResult runResult = ProcessUtils.run(command.split("\\s+"));
+                    if (runResult.getErrorReadingException() != null) {
+                        throw new RuntimeException(runResult.getErrorReadingException());
+                    }
+
+                    if (runResult.getOutputReadingException() != null) {
+                        throw new RuntimeException(runResult.getOutputReadingException());
+                    }
+
                     validationCode.accept(runResult);
                 });
     }
@@ -57,10 +65,10 @@ public class Cli {
     }
 
     private static CliOutput cliOutput(ProcessRunResult runResult) {
-        return new CliOutput("out", runResult.getOutput());
+        return new CliOutput("process output", runResult.getOutput());
     }
 
     private static CliOutput cliError(ProcessRunResult runResult) {
-        return new CliOutput("error", runResult.getError());
+        return new CliOutput("process error output", runResult.getError());
     }
 }

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/CliOutputListener.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/CliOutputListener.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class CliOutputListener {
+    private List<PredicateWithHandler> lineHandlers;
+
+    public CliOutputListener() {
+        this.lineHandlers = new ArrayList<>();
+    }
+
+    public void on(String partialLine, Runnable handler) {
+        lineHandlers.add(new PredicateWithHandler(new PartialLineMatch(partialLine), handler));
+    }
+
+    public Stream<PredicateWithHandler> lineHandlersStream() {
+        return lineHandlers.stream();
+    }
+
+    private static class PredicateWithHandler {
+        Predicate<String> predicate;
+        Runnable handler;
+
+        public PredicateWithHandler(Predicate<String> predicate, Runnable handler) {
+            this.predicate = predicate;
+            this.handler = handler;
+        }
+    }
+
+    private static class PartialLineMatch implements Predicate<String> {
+        private final String partialExpectation;
+
+        public PartialLineMatch(String partialExpectation) {
+            this.partialExpectation = partialExpectation;
+        }
+
+        @Override
+        public boolean test(String line) {
+            return line.contains(partialExpectation);
+        }
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessEnv.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessEnv.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twosigma.webtau.cli;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ProcessEnv {
+    public static final ProcessEnv EMPTY = new ProcessEnv(Collections.emptyMap());
+
+    private Map<String, String> env;
+
+    public ProcessEnv(Map<String, String> env) {
+        this.env = env;
+    }
+
+    public Map<String, String> getEnv() {
+        return env;
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessRunResult.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessRunResult.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli;
+
+import java.util.List;
+
+public class ProcessRunResult {
+    private int exitCode;
+    private List<String> output;
+    private List<String> error;
+
+    public ProcessRunResult(int exitCode, List<String> output, List<String> error) {
+        this.exitCode = exitCode;
+        this.output = output;
+        this.error = error;
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    public List<String> getOutput() {
+        return output;
+    }
+
+    public List<String> getError() {
+        return error;
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessRunResult.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessRunResult.java
@@ -16,6 +16,7 @@
 
 package com.twosigma.webtau.cli;
 
+import java.io.IOException;
 import java.util.List;
 
 public class ProcessRunResult {
@@ -23,10 +24,27 @@ public class ProcessRunResult {
     private List<String> output;
     private List<String> error;
 
-    public ProcessRunResult(int exitCode, List<String> output, List<String> error) {
+    private IOException outputReadingException;
+    private IOException errorReadingException;
+
+    public ProcessRunResult(int exitCode,
+                            List<String> output,
+                            List<String> error,
+                            IOException outputReadingException,
+                            IOException errorReadingException) {
         this.exitCode = exitCode;
         this.output = output;
         this.error = error;
+        this.outputReadingException = outputReadingException;
+        this.errorReadingException = errorReadingException;
+    }
+
+    public IOException getOutputReadingException() {
+        return outputReadingException;
+    }
+
+    public IOException getErrorReadingException() {
+        return errorReadingException;
     }
 
     public int getExitCode() {

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessUtils.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessUtils.java
@@ -17,18 +17,22 @@
 package com.twosigma.webtau.cli;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 
 public class ProcessUtils {
     private ProcessUtils() {
     }
 
-    public static ProcessRunResult run(String[] command) {
-        ProcessBuilder processBuilder = new ProcessBuilder(command);
+    public static ProcessRunResult run(String command, Map<String, String> env) {
+        ProcessBuilder processBuilder = new ProcessBuilder(splitCommand(command));
+        processBuilder.environment().putAll(env);
+
         try {
             Process process = processBuilder.start();
 
-            StreamGobbler outputGobbler = new StreamGobbler("output", process.getInputStream());
-            StreamGobbler errorGobbler = new StreamGobbler("error", process.getErrorStream());
+            StreamGobbler outputGobbler = new StreamGobbler(process.getInputStream());
+            StreamGobbler errorGobbler = new StreamGobbler(process.getErrorStream());
 
             Thread consumeErrorThread = new Thread(errorGobbler);
             Thread consumeOutThread = new Thread(outputGobbler);
@@ -49,5 +53,9 @@ public class ProcessUtils {
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    static String[] splitCommand(String command) {
+        return command.split("\\s+");
     }
 }

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessUtils.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessUtils.java
@@ -30,10 +30,16 @@ public class ProcessUtils {
             StreamGobbler outputGobbler = new StreamGobbler("output", process.getInputStream());
             StreamGobbler errorGobbler = new StreamGobbler("error", process.getErrorStream());
 
-            new Thread(errorGobbler).start();
-            new Thread(outputGobbler).start();
+            Thread consumeErrorThread = new Thread(errorGobbler);
+            Thread consumeOutThread = new Thread(outputGobbler);
+
+            consumeErrorThread.start();
+            consumeOutThread.start();
 
             process.waitFor();
+
+            consumeErrorThread.join();
+            consumeOutThread.join();
 
             return new ProcessRunResult(process.exitValue(), outputGobbler.getLines(), errorGobbler.getLines());
         } catch (IOException | InterruptedException e) {

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessUtils.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessUtils.java
@@ -41,7 +41,11 @@ public class ProcessUtils {
             consumeErrorThread.join();
             consumeOutThread.join();
 
-            return new ProcessRunResult(process.exitValue(), outputGobbler.getLines(), errorGobbler.getLines());
+            return new ProcessRunResult(process.exitValue(),
+                    outputGobbler.getLines(),
+                    errorGobbler.getLines(),
+                    outputGobbler.getException(),
+                    errorGobbler.getException());
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessUtils.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/ProcessUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli;
+
+import java.io.IOException;
+
+public class ProcessUtils {
+    private ProcessUtils() {
+    }
+
+    public static ProcessRunResult run(String[] command) {
+        ProcessBuilder processBuilder = new ProcessBuilder(command);
+        try {
+            Process process = processBuilder.start();
+
+            StreamGobbler outputGobbler = new StreamGobbler("output", process.getInputStream());
+            StreamGobbler errorGobbler = new StreamGobbler("error", process.getErrorStream());
+
+            new Thread(errorGobbler).start();
+            new Thread(outputGobbler).start();
+
+            process.waitFor();
+
+            return new ProcessRunResult(process.exitValue(), outputGobbler.getLines(), errorGobbler.getLines());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/StreamGobbler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/StreamGobbler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StreamGobbler implements Runnable {
+    private final String id;
+    private final InputStream stream;
+    private final List<String> lines;
+
+    private IOException exception;
+
+    public StreamGobbler(String id, InputStream stream) {
+        this.id = id;
+        this.stream = stream;
+        this.lines = new ArrayList<>();
+    }
+
+    public List<String> getLines() {
+        return lines;
+    }
+
+    @Override
+    public void run() {
+        InputStreamReader inputStreamReader = new InputStreamReader(stream);
+        BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+
+        try {
+            consume(bufferedReader);
+        } catch (IOException e) {
+            exception = e;
+        }
+    }
+
+    private void consume(BufferedReader bufferedReader) throws IOException {
+        for (;;) {
+            String line = bufferedReader.readLine();
+            if (line == null) {
+                break;
+            }
+
+            lines.add(line);
+        }
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/StreamGobbler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/StreamGobbler.java
@@ -48,6 +48,7 @@ public class StreamGobbler implements Runnable {
         try {
             consume(bufferedReader);
         } catch (IOException e) {
+            e.printStackTrace(); // TODO remove
             exception = e;
         }
     }

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/StreamGobbler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/StreamGobbler.java
@@ -24,14 +24,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class StreamGobbler implements Runnable {
-    private final String id;
     private final InputStream stream;
     private final List<String> lines;
 
     private IOException exception;
 
-    public StreamGobbler(String id, InputStream stream) {
-        this.id = id;
+    public StreamGobbler(InputStream stream) {
         this.stream = stream;
         this.lines = new ArrayList<>();
     }

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/StreamGobbler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/StreamGobbler.java
@@ -40,6 +40,10 @@ public class StreamGobbler implements Runnable {
         return lines;
     }
 
+    public IOException getException() {
+        return exception;
+    }
+
     @Override
     public void run() {
         InputStreamReader inputStreamReader = new InputStreamReader(stream);
@@ -48,7 +52,6 @@ public class StreamGobbler implements Runnable {
         try {
             consume(bufferedReader);
         } catch (IOException e) {
-            e.printStackTrace(); // TODO remove
             exception = e;
         }
     }

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliExitCode.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliExitCode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+import com.twosigma.webtau.expectation.ActualPath;
+
+public class CliExitCode implements CliResultExpectations {
+    private static final ActualPath path = new ActualPath("exitCode");
+    private int exitCode;
+
+    public CliExitCode(int exitCode) {
+        this.exitCode = exitCode;
+    }
+
+    @Override
+    public ActualPath actualPath() {
+        return path;
+    }
+
+    public int get() {
+        return exitCode;
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliExitCodeCompareToHandler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliExitCodeCompareToHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+import com.twosigma.webtau.expectation.ActualPath;
+import com.twosigma.webtau.expectation.equality.CompareToComparator;
+import com.twosigma.webtau.expectation.equality.CompareToHandler;
+
+public class CliExitCodeCompareToHandler implements CompareToHandler {
+    @Override
+    public boolean handleEquality(Object actual, Object expected) {
+        return handles(actual);
+    }
+
+    @Override
+    public boolean handleGreaterLessEqual(Object actual, Object expected) {
+        return handles(actual);
+    }
+
+    @Override
+    public void compareEqualOnly(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
+        comparator.compareUsingEqualOnly(actualPath, ((CliExitCode) actual).get(), expected);
+    }
+
+    @Override
+    public void compareGreaterLessEqual(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
+        comparator.compareIsGreaterOrEqual(actualPath, ((CliExitCode) actual).get(), expected);
+    }
+
+    private boolean handles(Object actual) {
+        return actual instanceof CliExitCode;
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliOutput.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliOutput.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+import com.twosigma.webtau.expectation.ActualPath;
+
+import java.util.List;
+
+public class CliOutput implements CliResultExpectations {
+    private String id;
+    private List<String> lines;
+
+    private String full;
+
+    public CliOutput(String id, List<String> lines) {
+        this.id = id;
+        this.lines = lines;
+        this.full = String.join("\n", lines);
+    }
+
+    @Override
+    public ActualPath actualPath() {
+        return new ActualPath(id);
+    }
+
+    public String get() {
+        return full;
+    }
+
+    public List<String> getLines() {
+        return lines;
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliOutputCompareToHandler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliOutputCompareToHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+import com.twosigma.webtau.expectation.ActualPath;
+import com.twosigma.webtau.expectation.equality.CompareToComparator;
+import com.twosigma.webtau.expectation.equality.CompareToHandler;
+
+public class CliOutputCompareToHandler implements CompareToHandler {
+    @Override
+    public boolean handleEquality(Object actual, Object expected) {
+        return actual instanceof CliOutput;
+    }
+
+    @Override
+    public void compareEqualOnly(CompareToComparator comparator, ActualPath actualPath, Object actual, Object expected) {
+        comparator.compareUsingEqualOnly(actualPath, ((CliOutput) actual).get(), expected);
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliOutputContainHandler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliOutputContainHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+import com.twosigma.webtau.expectation.ActualPath;
+import com.twosigma.webtau.expectation.contain.ContainAnalyzer;
+import com.twosigma.webtau.expectation.contain.ContainHandler;
+
+public class CliOutputContainHandler implements ContainHandler {
+    @Override
+    public boolean handle(Object actual, Object expected) {
+        return actual instanceof CliOutput;
+    }
+
+    @Override
+    public void analyzeContain(ContainAnalyzer containAnalyzer, ActualPath actualPath, Object actual, Object expected) {
+        containAnalyzer.contains(actualPath, ((CliOutput) actual).get(), expected);
+    }
+
+    @Override
+    public void analyzeNotContain(ContainAnalyzer containAnalyzer, ActualPath actualPath, Object actual, Object expected) {
+        containAnalyzer.notContains(actualPath, ((CliOutput) actual).get(), expected);
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliResultExpectations.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliResultExpectations.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+import com.twosigma.webtau.expectation.ActualPathAware;
+import com.twosigma.webtau.expectation.ActualValueExpectations;
+import com.twosigma.webtau.expectation.ValueMatcher;
+import com.twosigma.webtau.expectation.timer.ExpectationTimer;
+import com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder;
+import com.twosigma.webtau.reporter.StepReportOptions;
+import com.twosigma.webtau.reporter.ValueMatcherExpectationSteps;
+
+import static com.twosigma.webtau.reporter.TokenizedMessage.tokenizedMessage;
+
+public interface CliResultExpectations extends ActualValueExpectations, ActualPathAware {
+    @Override
+    default void should(ValueMatcher valueMatcher) {
+        ValueMatcherExpectationSteps.shouldStep(null, this, StepReportOptions.SKIP_START,
+                tokenizedMessage(IntegrationTestsMessageBuilder.id(actualPath().getPath())), valueMatcher);
+    }
+
+    @Override
+    default void shouldNot(ValueMatcher valueMatcher) {
+        ValueMatcherExpectationSteps.shouldNotStep(null, this, StepReportOptions.SKIP_START,
+                tokenizedMessage(IntegrationTestsMessageBuilder.id(actualPath().getPath())), valueMatcher);
+    }
+
+    @Override
+    default void waitTo(ValueMatcher valueMatcher, ExpectationTimer expectationTimer, long tickMillis, long timeOutMillis) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default void waitToNot(ValueMatcher valueMatcher, ExpectationTimer expectationTimer, long tickMillis, long timeOutMillis) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliSetupAndValidationFullHandler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliSetupAndValidationFullHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+import com.twosigma.webtau.cli.CliOutputListener;
+
+public interface CliSetupAndValidationFullHandler {
+    void setupAndHandle(CliOutputListener listener, int exitCode, CliOutput output, CliOutput error);
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliValidationExitCodeOutputHandler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliValidationExitCodeOutputHandler.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+public interface CliValidationExitCodeOutputHandler {
+    void handle(CliExitCode exitCode, CliOutput output, CliOutput error);
+}

--- a/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliValidationOutputOnlylHandler.java
+++ b/webtau-cli/src/main/java/com/twosigma/webtau/cli/expectation/CliValidationOutputOnlylHandler.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.expectation;
+
+public interface CliValidationOutputOnlylHandler {
+    void handle(CliOutput output, CliOutput error);
+}

--- a/webtau-cli/src/main/resources/META-INF/services/com.twosigma.webtau.expectation.contain.ContainHandler
+++ b/webtau-cli/src/main/resources/META-INF/services/com.twosigma.webtau.expectation.contain.ContainHandler
@@ -1,0 +1,1 @@
+com.twosigma.webtau.cli.expectation.CliOutputContainHandler

--- a/webtau-cli/src/main/resources/META-INF/services/com.twosigma.webtau.expectation.equality.CompareToHandler
+++ b/webtau-cli/src/main/resources/META-INF/services/com.twosigma.webtau.expectation.equality.CompareToHandler
@@ -1,0 +1,2 @@
+com.twosigma.webtau.cli.expectation.CliExitCodeCompareToHandler
+com.twosigma.webtau.cli.expectation.CliOutputCompareToHandler

--- a/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliJavaTest.java
+++ b/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliJavaTest.java
@@ -20,9 +20,9 @@ import org.junit.Test;
 
 import java.util.regex.Pattern;
 
-import static com.twosigma.webtau.Ddjt.*;
+import static com.twosigma.webtau.Ddjt.contain;
+import static com.twosigma.webtau.Ddjt.equal;
 import static com.twosigma.webtau.cli.Cli.cli;
-import static com.twosigma.webtau.cli.CliTestUtils.USER;
 import static com.twosigma.webtau.cli.CliTestUtils.nixOnly;
 
 public class CliJavaTest {
@@ -36,11 +36,11 @@ public class CliJavaTest {
     @Test
     public void outputAndExitCodeValidation() {
         nixOnly(() -> {
-            cli.run("ls -l", (exitCode, output, error) -> {
+            cli.run("scripts/hello", (exitCode, output, error) -> {
                 exitCode.should(equal(0));
 
-                output.should(equal(Pattern.compile(USER)));
-                output.should(contain(USER));
+                output.should(equal(Pattern.compile("hello")));
+                output.should(contain("world"));
             });
         });
     }

--- a/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliJavaTest.java
+++ b/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliJavaTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli;
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static com.twosigma.webtau.Ddjt.*;
+import static com.twosigma.webtau.cli.Cli.cli;
+import static com.twosigma.webtau.cli.CliTestUtils.USER;
+import static com.twosigma.webtau.cli.CliTestUtils.nixOnly;
+
+public class CliJavaTest {
+    @Test
+    public void outputOnlyValidation() {
+        cli.run("ls -l", (output, error) -> {
+
+        });
+    }
+
+    @Test
+    public void outputAndExitCodeValidation() {
+        nixOnly(() -> {
+            cli.run("ls -l", (exitCode, output, error) -> {
+                exitCode.should(equal(0));
+
+                output.should(equal(Pattern.compile(USER)));
+                output.should(contain(USER));
+            });
+        });
+    }
+}

--- a/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliJavaTest.java
+++ b/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliJavaTest.java
@@ -44,4 +44,13 @@ public class CliJavaTest {
             });
         });
     }
+
+    @Test
+    public void envVars() {
+        nixOnly(() -> {
+            cli.run("scripts/hello", cli.env("NAME", "Java"), (exitCode, output, error) -> {
+                output.should(contain("hello world Java"));
+            });
+        });
+    }
 }

--- a/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliTestUtils.java
+++ b/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliTestUtils.java
@@ -17,7 +17,6 @@
 package com.twosigma.webtau.cli;
 
 class CliTestUtils {
-    static final String USER = System.getProperty("user.name");
     private static final String OS = System.getProperty("os.name");
 
     static void nixOnly(Runnable code) {

--- a/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliTestUtils.java
+++ b/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliTestUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli;
+
+class CliTestUtils {
+    static final String USER = System.getProperty("user.name");
+    private static final String OS = System.getProperty("os.name");
+
+    static void nixOnly(Runnable code) {
+        if (OS.toLowerCase().contains("win")) {
+            return;
+        }
+
+        code.run();
+    }
+}

--- a/webtau-core/pom.xml
+++ b/webtau-core/pom.xml
@@ -35,12 +35,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <type>pom</type>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -49,6 +43,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <scope>test</scope>
+            <type>pom</type>
         </dependency>
     </dependencies>
 

--- a/webtau-http-groovy/pom.xml
+++ b/webtau-http-groovy/pom.xml
@@ -45,12 +45,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <type>pom</type>
-        </dependency>
-
-        <dependency>
             <groupId>com.twosigma.webtau</groupId>
             <artifactId>webtau-test-server</artifactId>
             <version>${project.version}</version>

--- a/webtau-junit5-examples/pom.xml
+++ b/webtau-junit5-examples/pom.xml
@@ -62,7 +62,6 @@
             <groupId>com.twosigma.webtau</groupId>
             <artifactId>webtau-junit5-groovy</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/webtau-junit5-examples/src/test/groovy/com/example/tests/junit5/DynamicTestsGroovyTest.groovy
+++ b/webtau-junit5-examples/src/test/groovy/com/example/tests/junit5/DynamicTestsGroovyTest.groovy
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.TestFactory
 class DynamicTestsGroovyTest {
     @TestFactory
     def "individual tests use generated display labels"() {
-        ["price", "quantity", "outcome"] {
+        ["price" | "quantity" | "outcome"] {
         _________________________________
-          10     |  30      |  300
-          -10    |  30      | -300
+          10     |  30        |  300
+          -10    |  30        | -300
         }.test {
             PriceCalculator.calculate(price, quantity).should == outcome
         }
@@ -17,10 +17,10 @@ class DynamicTestsGroovyTest {
 
     @TestFactory
     def "individual tests can use an optional display label to clarify the use case"() {
-        ["label",           "price", "quantity", "outcome"] {
+        ["label"           | "price" | "quantity" | "outcome"] {
         ___________________________________________________
-          "positive price" | 10     |  30      |  300
-          "negative price" | -10    |  30      | -300
+          "positive price" | 10      |  30        |  300
+          "negative price" | -10     |  30        | -300
         }.test {
             PriceCalculator.calculate(price, quantity).should == outcome
         }
@@ -28,9 +28,9 @@ class DynamicTestsGroovyTest {
 
     @TestFactory
     def "a null display label is treated as the String 'null'"() {
-        ["label",           "price", "quantity", "outcome"] {
+        ["label"           | "price" | "quantity" | "outcome"] {
         ___________________________________________________
-          null             | 0      |  30      | 0
+          null             | 0       |  30        | 0
         }.test {
             PriceCalculator.calculate(price, quantity).should == outcome
         }

--- a/webtau-junit5-groovy/pom.xml
+++ b/webtau-junit5-groovy/pom.xml
@@ -39,14 +39,6 @@
             <groupId>com.twosigma.webtau</groupId>
             <artifactId>webtau-core-groovy</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <scope>test</scope>
-            <type>pom</type>
         </dependency>
     </dependencies>
 </project>

--- a/webtau-junit5-groovy/pom.xml
+++ b/webtau-junit5-groovy/pom.xml
@@ -41,5 +41,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <scope>test</scope>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Initial DSL for cli testing. Not exposed through `WebTauDsl` yet.  `CliJavaTest` shows basic java syntax. Approach is similar to `Http.`. 

It is most likely going to change so considering it is a private API for now. Want to put it out there so we can start conversation around. 

One of the syntax I want to be able to achieve follows
```
cli.run('command...') {
    on('partial match') {
         http.get( ... ) { 
         }
    }

    onOptional('partial match') {
        http.del(....) {
        }
    }

    output.should contain('blah')
}
```

Alternatively we may try to use `waitTo` (not really sure how to approach this)
```
cli.run('command...') {
    line.waitTo == ~/partial match/ 
    http.get( ... ) { 
    }

    output.should contain('blah')
}
```