### PR TITLE
Shortcuts and sanity checks for number of threads config

### DIFF
--- a/webtau-docs/webtau/REST/test-execution.md
+++ b/webtau-docs/webtau/REST/test-execution.md
@@ -10,7 +10,8 @@ scenarios** are still executed sequentially.
 For large test suites, it is therefore advisable to create many small focused scenario files instead of few large files.
 
 To enable parallel execution, specify the `numberOfThreads` configuration property either through the configuration file
-or as a CLI parameter.  This property dictates the maximum number of threads on which to run tests.
+or as a CLI parameter.  This property dictates the maximum number of threads on which to run tests.  Alternatively,
+set `numberOfThreads` to `-1` and webtau will use as many threads as there are scenario files.
 
 Note: scenario file execution order is not guaranteed.
 

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauGroovyCliArgsConfigHandler.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauGroovyCliArgsConfigHandler.groovy
@@ -29,7 +29,7 @@ import static com.twosigma.webtau.cfg.WebTauConfig.getCfg
 
 class WebTauGroovyCliArgsConfigHandler implements WebTauConfigHandler {
     private static final ConfigValue numberOfThreads = declare("numberOfThreads",
-            "number of threads on which to run test files (one file per thread)",
+            "number of threads on which to run test files (one file per thread), -1 will use as many threads as there are files",
             { -> 1 })
 
     private String[] args

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
@@ -89,7 +89,7 @@ class WebTauCliApp implements StandaloneTestListener, ReportGenerator {
             runTests()
         }
 
-        if (!runner.exclusiveTests.isEmpty()) {
+        if (runner.hasExclusiveTests()) {
             ConsoleOutputs.out(Color.YELLOW, 'sscenario is found, only use it during local development')
             exitHandler.accept(1)
         } else {

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
@@ -167,8 +167,9 @@ class WebTauCliApp implements StandaloneTestListener, ReportGenerator {
     }
 
     private void runTests() {
-        if (WebTauGroovyCliArgsConfigHandler.getNumberOfThreads() > 1) {
-            runner.runTestsInParallel(WebTauGroovyCliArgsConfigHandler.getNumberOfThreads())
+        def numThreads = WebTauGroovyCliArgsConfigHandler.getNumberOfThreads()
+        if (numThreads > 1 || numThreads == -1) {
+            runner.runTestsInParallel(numThreads)
         } else {
             runner.runTests()
         }

--- a/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/RegisteredTests.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/RegisteredTests.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.twosigma.webtau.runner.standalone
 
 import java.nio.file.Path

--- a/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/RegisteredTests.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/RegisteredTests.groovy
@@ -1,0 +1,45 @@
+package com.twosigma.webtau.runner.standalone
+
+import java.nio.file.Path
+
+class RegisteredTests {
+    private List<StandaloneTest> tests = []
+    private List<StandaloneTest> exclusiveTests = []
+
+    void add(StandaloneTest test) {
+        tests.add(test)
+    }
+
+    void addExclusive(StandaloneTest test) {
+        exclusiveTests.add(test)
+    }
+
+    void clear() {
+        tests = []
+        exclusiveTests = []
+    }
+
+    int count(Closure closure) {
+        return tests.count(closure)
+    }
+
+    boolean hasExclusiveTests() {
+        return !exclusiveTests.isEmpty()
+    }
+
+    List<StandaloneTest> getTests() {
+        return tests.asImmutable()
+    }
+
+    private List<StandaloneTest> testsToRun() {
+        return exclusiveTests.isEmpty() ? tests : exclusiveTests
+    }
+
+    Map<Path, List<StandaloneTest>> testsByFile() {
+        return testsToRun().groupBy { it.filePath }
+    }
+
+    List<StandaloneTest> testsToSkip() {
+        return (exclusiveTests.isEmpty() ? [] : tests).asImmutable()
+    }
+}

--- a/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunner.groovy
+++ b/webtau-standalone-runner-groovy/src/main/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunner.groovy
@@ -142,7 +142,9 @@ class StandaloneTestRunner {
 
     int numThreadsToUse(int maxNumberOfThreads) {
         int numTestsToRun = registeredTests.testsByFile().size()
-        return Math.min(maxNumberOfThreads, numTestsToRun)
+        return maxNumberOfThreads == -1 ?
+            numTestsToRun :
+            Math.min(maxNumberOfThreads, numTestsToRun)
     }
 
     void runTestsInParallel(int maxNumberOfThreads) {

--- a/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
+++ b/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
@@ -129,6 +129,12 @@ class StandaloneTestRunnerTest {
         runner.numThreadsToUse(3).should == 2
     }
 
+    @Test
+    void "should use number of files if requested -1 threads"() {
+        def runner = createRunner("StandaloneTest.groovy", "withDisabled.groovy")
+        runner.numThreadsToUse(-1).should == 2
+    }
+
     private static void assertInitFailed(StandaloneTestRunner runner, String message) {
         runner.tests.size().should == 1
 

--- a/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
+++ b/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
@@ -117,6 +117,18 @@ class StandaloneTestRunnerTest {
         assertInitFailed(runner, 'executing <running errand> outside of scenario is not supported')
     }
 
+    @Test
+    void "should use requested thread count if smaller than number of files"() {
+        def runner = createRunner("StandaloneTest.groovy", "withDisabled.groovy")
+        runner.numThreadsToUse(1).should == 1
+    }
+
+    @Test
+    void "should use number of files if smaller than requested thread count"() {
+        def runner = createRunner("StandaloneTest.groovy", "withDisabled.groovy")
+        runner.numThreadsToUse(3).should == 2
+    }
+
     private static void assertInitFailed(StandaloneTestRunner runner, String message) {
         runner.tests.size().should == 1
 
@@ -126,10 +138,10 @@ class StandaloneTestRunnerTest {
         test.reportTestEntry.exception.message.should == message
     }
 
-    private static StandaloneTestRunner createRunner(String scenarioFile) {
+    private static StandaloneTestRunner createRunner(String... scenarioFiles) {
         def workingDir = Paths.get("test-scripts")
         def runner = new StandaloneTestRunner(GroovyStandaloneEngine.createWithDelegatingEnabled(workingDir, []), workingDir)
-        runner.process(new TestFile(Paths.get(scenarioFile)), this)
+        scenarioFiles.each { runner.process(new TestFile(Paths.get(it)), this) }
 
         return runner
     }


### PR DESCRIPTION
Fixes #195

This PR does two things:
1. cap the size of the thread pool to the number of files.  i.e. if someone specifies 10 threads but there are only 2 files, we'll only create 2 threads.
1. provide a shortcut for saying use as many threads as we have files.  I've used -1 to indicate this though I'm not 100% happy about that.  Having said that, I don't really want to introduce another flag to indicate that's what we want because the interaction between the two configs might be a little confusing.  Thoughts welcome.