### PR TITLE
Webtau uber jar + shading attempt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <module>webtau-maven-plugin-test</module>
         <module>webtau-maven-plugin-test-skip</module>
         <module>webtau-report-testing</module>
+        <module>webtau-shaded</module>
         <module>webtau-dist</module>
         <module>webtau</module>
     </modules>

--- a/webtau-dist/pom.xml
+++ b/webtau-dist/pom.xml
@@ -41,6 +41,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/webtau-dist/pom.xml
+++ b/webtau-dist/pom.xml
@@ -25,12 +25,21 @@
     </parent>
 
     <artifactId>webtau-dist</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
             <groupId>com.twosigma.webtau</groupId>
-            <artifactId>webtau-groovy</artifactId>
+            <artifactId>webtau-shaded</artifactId>
+            <classifier>shaded</classifier>
+            <scope>runtime</scope>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.twosigma.webtau</groupId>
+                    <artifactId>webtau-groovy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/webtau-shaded/pom.xml
+++ b/webtau-shaded/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+  ~  
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~  
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~  
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.twosigma.webtau</groupId>
+        <artifactId>webtau-parent</artifactId>
+        <version>1.11-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>webtau-shaded</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.twosigma.webtau</groupId>
+            <artifactId>webtau-groovy</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <relocations>
+                                <relocation>
+                                    <pattern>groovy</pattern>
+                                    <shadedPattern>webtaushaded.groovy</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org</pattern>
+                                    <shadedPattern>webtaushaded.org</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.atlassian</pattern>
+                                    <shadedPattern>webtaushaded.com.atlassian</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.sun</pattern>
+                                    <shadedPattern>webtaushaded.com.sun</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>webtaushaded.com.fasterxml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>webtaushaded.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.damnhandy</pattern>
+                                    <shadedPattern>webtaushaded.com.damnhandy</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.thoughtworks</pattern>
+                                    <shadedPattern>webtaushaded.com.thoughtworks</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.github</pattern>
+                                    <shadedPattern>webtaushaded.com.github</shadedPattern>
+                                </relocation>
+                            </relocations>
+
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.GroovyResourceTransformer">
+                                    <extModuleName>groovy-datetime</extModuleName>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/webtau-shaded/pom.xml
+++ b/webtau-shaded/pom.xml
@@ -33,6 +33,12 @@
             <groupId>com.twosigma.webtau</groupId>
             <artifactId>webtau-groovy</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
@@ -53,48 +59,24 @@
                             <shadedClassifierName>shaded</shadedClassifierName>
                             <relocations>
                                 <relocation>
-                                    <pattern>groovy</pattern>
-                                    <shadedPattern>webtaushaded.groovy</shadedPattern>
+                                    <pattern>org.</pattern>
+                                    <shadedPattern>webtaushaded.org.</shadedPattern>
+                                    <excludes>
+                                        <exclude>org.codehaus.**</exclude>
+                                    </excludes>
                                 </relocation>
+
                                 <relocation>
-                                    <pattern>org</pattern>
-                                    <shadedPattern>webtaushaded.org</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.atlassian</pattern>
-                                    <shadedPattern>webtaushaded.com.atlassian</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.sun</pattern>
-                                    <shadedPattern>webtaushaded.com.sun</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.fasterxml</pattern>
-                                    <shadedPattern>webtaushaded.com.fasterxml</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>webtaushaded.com.google</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.damnhandy</pattern>
-                                    <shadedPattern>webtaushaded.com.damnhandy</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.thoughtworks</pattern>
-                                    <shadedPattern>webtaushaded.com.thoughtworks</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.github</pattern>
-                                    <shadedPattern>webtaushaded.com.github</shadedPattern>
+                                    <pattern>com.</pattern>
+                                    <shadedPattern>webtaushaded.com.</shadedPattern>
+                                    <excludes>
+                                        <exclude>com.twosigma.**</exclude>
+                                    </excludes>
                                 </relocation>
                             </relocations>
 
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.GroovyResourceTransformer">
-                                    <extModuleName>groovy-datetime</extModuleName>
-                                </transformer>
                             </transformers>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Not working yet. Current problem is I shade groovy as well and even though I use transformations, it doesn't shade properly `META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule`. I think it is because it is not in a standard `services` dir. 

Should we even shade Groovy? One of the reason I want to shade is to mitigate monorepo deps problems. Alternatively I could separate into groovy and non groovy jars.