### PR TITLE
getting started extension point for company specific overrides

### DIFF
--- a/webtau-docs/webtau/REST/getting-started.md
+++ b/webtau-docs/webtau/REST/getting-started.md
@@ -1,4 +1,4 @@
-:include-markdown: installation-groovy-runner.md
+:include-markdown: {firstAvailable: ["installation-company-specific-groovy-runner.md", "installation-groovy-runner.md"]}
 
 # Minimal Groovy Setup
 

--- a/webtau-docs/webtau/UI/getting-started.md
+++ b/webtau-docs/webtau/UI/getting-started.md
@@ -1,4 +1,4 @@
-:include-markdown: installation-groovy-runner.md
+:include-markdown: {firstAvailable: ["installation-company-specific-groovy-runner.md", "installation-groovy-runner.md"]}
 
 # Bare Minimum
 


### PR DESCRIPTION
This is to allow docs rebuild with custom getting started step. I.e. if `webtau` command line is available globally, then downloading zip is not required.
For that docs need to be rebuilt and hosted within a company with the additional .md file present.