### PR TITLE
add --example option to bootstrap examples ready to be ran

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
         <module>webtau-testapp</module>
         <module>webtau-config</module>
         <module>webtau-feature-testing</module>
+        <module>webtau-cli-testing</module>
         <module>webtau-docs</module>
         <module>webtau-maven-plugin</module>
         <module>webtau-maven-plugin-test</module>

--- a/webtau-cli-testing/pom.xml
+++ b/webtau-cli-testing/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+  ~  
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~  
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~  
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.twosigma.webtau</groupId>
+        <artifactId>webtau-parent</artifactId>
+        <version>1.11-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>webtau-cli-testing</artifactId>
+
+    <description>
+        End to end tests of webtau CLI
+    </description>
+</project>

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
@@ -33,11 +33,13 @@ import static com.twosigma.webtau.cfg.ConfigValue.declare;
 import static com.twosigma.webtau.cfg.ConfigValue.declareBoolean;
 
 public class WebTauConfig {
+    public static String CONFIG_FILE_NAME_DEFAULT = "webtau.cfg";
+
     private static final List<WebTauConfigHandler> handlers = discoverConfigHandlers();
 
     private static final Supplier<Object> NO_DEFAULT = () -> null;
 
-    private final ConfigValue config = declare("config", "config file path", () -> "webtau.cfg");
+    private final ConfigValue config = declare("config", "config file path", () -> CONFIG_FILE_NAME_DEFAULT);
     private final ConfigValue interactive = declareBoolean("interactive", "use CLI interactive mode");
     private final ConfigValue env = declare("env", "environment id", () -> "local");
     private final ConfigValue url = declare("url", "base url for application under test", NO_DEFAULT);

--- a/webtau-docs/webtau/REST/getting-started.md
+++ b/webtau-docs/webtau/REST/getting-started.md
@@ -2,19 +2,27 @@
 
 # Minimal Groovy Setup
 
-:include-file: examples/scenarios/rest/simpleGet.groovy {title: "examples/scenarios/rest/simpleGet.groovy"}
+Generate webtau examples 
 
-To run test, navigate to `examples` dir and
+:include-cli-command: webtau --example
 
-:include-cli-command: webtau scenarios/rest/simpleGet.groovy --url=https://my-server {paramsToHighlight: "url"}
+Navigate into `todo` example
+
+:include-cli-command: cd examples/todo
+
+:include-file: examples/todo/todolist.groovy {title: "todolist.groovy"}
+
+To run test
+
+:include-cli-command: webtau todolist.groovy --url=https://jsonplaceholder.typicode.com {paramsToHighlight: "url"}
 
 :include-markdown: common/note-package-import.md
 
-## Config File
+## Groovy Config File
 
 Url parameter can be moved to a `webtau.cfg` file.
 
-:include-file: examples/scenarios/rest/urlOnly.cfg {title: "examples/scenarios/rest/webtau.cfg"}
+:include-file: examples/todo/webtau.cfg {title: "webtau.cfg"}
 
 [Specify multiple environments](configuration/environments) to streamline test execution.
 
@@ -27,10 +35,15 @@ Java: :include-file: maven/java-dep.xml {title: "Maven Dependency"}
 
 ```tabs
 Groovy:
-:include-file: com/example/tests/junit4/WeatherGroovyIT.groovy {title: "JUnit 4 example"}
+:include-file: com/example/tests/junit4/TodoListGroovyIT.groovy {title: "JUnit 4 example"}
  
 Java:
-:include-file: com/example/tests/junit4/WeatherJavaIT.java {title: "JUnit 4 example"}
-
+:include-file: com/example/tests/junit4/TodoListJavaIT.java {title: "JUnit 4 example"}
 ```
+
+## Junit Config File
+
+Add `webtau.properties` to test class path
+
+:include-file: src/test/resources/webtau.properties {title: "webtau.properties"}
 

--- a/webtau-docs/webtau/common/note-package-import.md
+++ b/webtau-docs/webtau/common/note-package-import.md
@@ -1,2 +1,2 @@
-Note: using `package` and `import` is optional and is mainly for IDE auto completion. Imports will be added implicitly
+Note: using `import` is optional and is mainly for IDE auto completion. Imports are added implicitly
 during command line run.  

--- a/webtau-docs/webtau/lookup-paths
+++ b/webtau-docs/webtau/lookup-paths
@@ -1,9 +1,10 @@
-../../webtau-groovy/
 ../../webtau-core/src/test/groovy
 ../../webtau-core/src/test/java
 ../../webtau-core-groovy/src/test/groovy
 ../../webtau-core/target/test-classes
+../../webtau-groovy/
 ../../webtau-groovy/src/main/groovy
+../../webtau-groovy/src/main/resources
 ../../webtau-feature-testing
 ../../webtau-feature-testing/examples
 ../../webtau-http/
@@ -18,6 +19,7 @@
 ../../webtau-pdf/src/test/groovy
 ../../webtau-testapp/src/main/java
 ../../webtau-http/src/test/java
+../../webtau-junit4-examples
 ../../webtau-junit4-examples/src/test/groovy
 ../../webtau-junit4-examples/src/test/java
 ../../webtau-junit5-examples/src/test/groovy

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
@@ -16,14 +16,19 @@
 
 package com.twosigma.webtau.cfg
 
+import com.twosigma.webtau.examples.ExamplesScaffolder
 import org.apache.commons.cli.CommandLine
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.HelpFormatter
 import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
 
+import java.nio.file.Paths
+
 class WebTauCliArgsConfig {
-    public static final String CLI_SOURCE = "command line argument"
+    private static final String CLI_SOURCE = "command line argument"
+    private static final String HELP_OPTION = "help"
+    private static final String EXAMPLE_OPTION = "example"
 
     private final WebTauConfig cfg
 
@@ -62,16 +67,26 @@ class WebTauCliArgsConfig {
         Options options = createOptions()
         commandLine = createCommandLine(args, options)
 
-        if (commandLine.hasOption("help") || commandLine.argList.isEmpty()) {
-            HelpFormatter helpFormatter = new HelpFormatter()
-
-            def header = "version: " + WebTauMeta.version
-            helpFormatter.printHelp("webtau [options] [testFile1] [testFile2]", header, options, "")
-            exitHandler.exit(1)
-            return
+        if (commandLine.hasOption(EXAMPLE_OPTION)) {
+            scaffoldExamples()
+        } else if (commandLine.hasOption(HELP_OPTION) || commandLine.argList.isEmpty()) {
+            printHelp(options)
+        } else {
+            testFiles = new ArrayList<>(commandLine.argList)
         }
+    }
 
-        testFiles = new ArrayList<>(commandLine.argList)
+    private void scaffoldExamples() {
+        ExamplesScaffolder.scaffold(Paths.get(""))
+        exitHandler.exit(1)
+    }
+
+    private void printHelp(Options options) {
+        HelpFormatter helpFormatter = new HelpFormatter()
+
+        def header = "version: " + WebTauMeta.version
+        helpFormatter.printHelp("webtau [options] [testFile1] [testFile2]", header, options, "")
+        exitHandler.exit(0)
     }
 
     private static CommandLine createCommandLine(String[] args, Options options) {
@@ -91,7 +106,8 @@ class WebTauCliArgsConfig {
 
     private Options createOptions() {
         def options = new Options()
-        options.addOption(null, "help", false, "print help")
+        options.addOption(null, HELP_OPTION, false, "print help")
+        options.addOption(null, EXAMPLE_OPTION, false, "generate basic examples")
 
         cfg.getCfgValuesStream().each {
             options.addOption(null, it.key, !it.isBoolean(), it.description)

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
@@ -78,7 +78,7 @@ class WebTauCliArgsConfig {
 
     private void scaffoldExamples() {
         ExamplesScaffolder.scaffold(Paths.get(""))
-        exitHandler.exit(1)
+        exitHandler.exit(0)
     }
 
     private void printHelp(Options options) {
@@ -86,7 +86,7 @@ class WebTauCliArgsConfig {
 
         def header = "version: " + WebTauMeta.version
         helpFormatter.printHelp("webtau [options] [testFile1] [testFile2]", header, options, "")
-        exitHandler.exit(0)
+        exitHandler.exit(1)
     }
 
     private static CommandLine createCommandLine(String[] args, Options options) {

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/examples/DefaultExamplesProvider.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/examples/DefaultExamplesProvider.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.examples
+
+import com.twosigma.webtau.utils.ResourceUtils
+
+class DefaultExamplesProvider implements ExamplesProvider {
+    @Override
+    List<Example> provide() {
+        return [
+                fromResource('todo', 'todolist.groovy'),
+        ]
+    }
+
+    private static Example fromResource(dirName, fileName) {
+        return new Example(dirName,
+                fileName,
+                ResourceUtils.textContent("examples/${dirName}/webtau.cfg"),
+                ResourceUtils.textContent("examples/${dirName}/${fileName}"),
+        )
+    }
+}

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/examples/Example.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/examples/Example.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.examples
+
+import groovy.transform.Canonical
+
+@Canonical
+class Example {
+    String dirName
+    String fileName
+    String configBody
+    String exampleBody
+}

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/examples/ExamplesProvider.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/examples/ExamplesProvider.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.examples
+
+interface ExamplesProvider {
+    List<Example> provide()
+}

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/examples/ExamplesScaffolder.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/examples/ExamplesScaffolder.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.examples
+
+import com.twosigma.webtau.cfg.WebTauConfig
+import com.twosigma.webtau.console.ansi.Color
+import com.twosigma.webtau.utils.FileUtils
+import com.twosigma.webtau.utils.ServiceLoaderUtils
+
+import java.nio.file.Path
+
+import static com.twosigma.webtau.console.ConsoleOutputs.out
+
+class ExamplesScaffolder {
+    private static List<ExamplesProvider> providers = discoverProviders()
+
+    private ExamplesScaffolder() {
+    }
+
+    static void scaffold(Path root) {
+        providers
+                .collectMany { it.provide() }
+                .each {
+                    scaffoldExample(root, it)
+                }
+    }
+
+    private static void scaffoldExample(Path root, Example example) {
+        def dir = root.resolve("examples").resolve(example.dirName)
+
+        out("generating example: ", Color.GREEN, example.dirName,
+                Color.PURPLE, " (cd ", dir.toAbsolutePath(), " && webtau ${example.fileName})")
+
+        FileUtils.writeTextContent(dir.resolve(example.fileName), example.exampleBody)
+        FileUtils.writeTextContent(dir.resolve(WebTauConfig.CONFIG_FILE_NAME_DEFAULT), example.configBody)
+    }
+
+    private static List<ExamplesProvider> discoverProviders() {
+        def providers = ServiceLoaderUtils.load(ExamplesProvider)
+        return providers.empty ? Collections.singletonList(new DefaultExamplesProvider()) : providers
+    }
+}

--- a/webtau-groovy/src/main/resources/examples/todo/todolist.groovy
+++ b/webtau-groovy/src/main/resources/examples/todo/todolist.groovy
@@ -1,0 +1,8 @@
+import static com.twosigma.webtau.WebTauGroovyDsl.*
+
+scenario('fetch todo item') {
+    http.get('/todos/1') {
+        title.should == 'delectus aut autem'
+        completed.should == false
+    }
+}

--- a/webtau-groovy/src/main/resources/examples/todo/webtau.cfg
+++ b/webtau-groovy/src/main/resources/examples/todo/webtau.cfg
@@ -1,0 +1,1 @@
+url = "https://jsonplaceholder.typicode.com/"

--- a/webtau-junit4-examples/src/test/groovy/com/example/tests/featuretest/JUnitFeatureTestRunner.groovy
+++ b/webtau-junit4-examples/src/test/groovy/com/example/tests/featuretest/JUnitFeatureTestRunner.groovy
@@ -16,6 +16,7 @@
 
 package com.example.tests.featuretest
 
+import com.twosigma.webtau.cfg.WebTauConfig
 import com.twosigma.webtau.featuretesting.WebTauEndToEndTestValidator
 import com.twosigma.webtau.reporter.StepReporter
 import com.twosigma.webtau.reporter.StepReporters
@@ -29,11 +30,13 @@ class JUnitFeatureTestRunner extends RunListener implements StepReporter {
     private Map<String, Object> scenariosDetails
     private Map<String, Object> capturedStepsSummary
 
-    void runAndValidate(Class testClass) {
+    void runAndValidate(Class testClass, String baseUrl) {
         JUnitCore junit = new JUnitCore()
 
         junit.addListener(this)
         scenariosDetails = [:]
+
+        WebTauConfig.cfg.setBaseUrl(baseUrl)
 
         StepReporters.withAdditionalReporter(this) {
             junit.run(testClass)

--- a/webtau-junit4-examples/src/test/groovy/com/example/tests/junit4/TodoListGroovyIT.groovy
+++ b/webtau-junit4-examples/src/test/groovy/com/example/tests/junit4/TodoListGroovyIT.groovy
@@ -1,0 +1,18 @@
+package com.example.tests.junit4
+
+import com.twosigma.webtau.junit4.WebTauRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static com.twosigma.webtau.WebTauDsl.*
+
+@RunWith(WebTauRunner)
+class TodoListGroovyIT {
+    @Test
+    void "fetch todo item"() {
+        http.get('/todos/1') {
+            title.should == 'delectus aut autem'
+            completed.should == false
+        }
+    }
+}

--- a/webtau-junit4-examples/src/test/groovy/com/example/tests/junit4/WebTauFeaturesJUnitTest.groovy
+++ b/webtau-junit4-examples/src/test/groovy/com/example/tests/junit4/WebTauFeaturesJUnitTest.groovy
@@ -17,7 +17,6 @@
 package com.example.tests.junit4
 
 import com.example.tests.featuretest.JUnitFeatureTestRunner
-import com.twosigma.webtau.cfg.WebTauConfig
 import com.twosigma.webtau.featuretesting.WebTauRestFeaturesTestData
 import com.twosigma.webtau.http.testserver.TestServer
 import org.junit.AfterClass
@@ -29,12 +28,12 @@ class WebTauFeaturesJUnitTest {
 
     private static final JUnitFeatureTestRunner testRunner = new JUnitFeatureTestRunner()
 
+    private static final TODO_BASE_URL = 'https://jsonplaceholder.typicode.com/'
+
     @BeforeClass
     static void startServer() {
         testServer.startRandomPort()
         WebTauRestFeaturesTestData.registerEndPoints(testServer)
-
-        WebTauConfig.cfg.setBaseUrl(testServer.uri.toString())
     }
 
     @AfterClass
@@ -44,11 +43,21 @@ class WebTauFeaturesJUnitTest {
 
     @Test
     void weatherJavaTest() {
-        testRunner.runAndValidate(WeatherJavaIT)
+        testRunner.runAndValidate(WeatherJavaIT, testServer.uri.toString())
     }
 
     @Test
     void weatherGroovyTest() {
-        testRunner.runAndValidate(WeatherGroovyIT)
+        testRunner.runAndValidate(WeatherGroovyIT, testServer.uri.toString())
+    }
+
+    @Test
+    void todoListJavaTest() {
+        testRunner.runAndValidate(TodoListJavaIT, TODO_BASE_URL)
+    }
+
+    @Test
+    void todoListGroovyTest() {
+        testRunner.runAndValidate(TodoListGroovyIT, TODO_BASE_URL)
     }
 }

--- a/webtau-junit4-examples/src/test/java/com/example/tests/junit4/TodoListJavaIT.java
+++ b/webtau-junit4-examples/src/test/java/com/example/tests/junit4/TodoListJavaIT.java
@@ -1,0 +1,18 @@
+package com.example.tests.junit4;
+
+import com.twosigma.webtau.junit4.WebTauRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.twosigma.webtau.WebTauGroovyDsl.*;
+
+@RunWith(WebTauRunner.class)
+public class TodoListJavaIT {
+    @Test
+    public void fetchTodoItem() {
+        http.get("/todos/1", (header, body) -> {
+            body.get("title").should(equal("delectus aut autem"));
+            body.get("completed").should(equal(false));
+        });
+    }
+}

--- a/webtau-junit4-examples/src/test/resources/webtau.properties
+++ b/webtau-junit4-examples/src/test/resources/webtau.properties
@@ -1,1 +1,1 @@
-url = http://localhost:8080
+url = https://jsonplaceholder.typicode.com/

--- a/webtau-junit4-examples/test-expectations/TodoListGroovyIT/run-details.json
+++ b/webtau-junit4-examples/test-expectations/TodoListGroovyIT/run-details.json
@@ -1,0 +1,5 @@
+{
+  "fetch todo item" : {
+    "numberOfSuccessful" : 4
+  }
+}

--- a/webtau-junit4-examples/test-expectations/TodoListJavaIT/run-details.json
+++ b/webtau-junit4-examples/test-expectations/TodoListJavaIT/run-details.json
@@ -1,0 +1,5 @@
+{
+  "fetchTodoItem" : {
+    "numberOfSuccessful" : 4
+  }
+}


### PR DESCRIPTION
Idea is users can just do `webtau --example` and run generated examples without any setup to get the feel for the tool.
Folks who wrap webtau can register their own examples that are, say, company specific.

There is a new module `webtau-cli-testing` that is a placeholder for now.
Need to figure out how to make webtau cli testing capabilities to test webtau cli itself (unzipped dist after assembly). 