### PR TITLE
Matchers as a separate class. Ddjt->WebTauCore. deprecate beGreater/Less

### DIFF
--- a/webtau-browser/src/main/java/com/twosigma/webtau/browser/expectation/ElementValueCompareToHandler.java
+++ b/webtau-browser/src/main/java/com/twosigma/webtau/browser/expectation/ElementValueCompareToHandler.java
@@ -21,7 +21,7 @@ import com.twosigma.webtau.expectation.ActualPath;
 import com.twosigma.webtau.expectation.equality.CompareToComparator;
 import com.twosigma.webtau.expectation.equality.CompareToHandler;
 
-import static com.twosigma.webtau.Ddjt.createActualPath;
+import static com.twosigma.webtau.WebTauCore.createActualPath;
 
 public class ElementValueCompareToHandler implements CompareToHandler {
     @Override

--- a/webtau-browser/src/main/java/com/twosigma/webtau/browser/expectation/PageElementCompareToHandler.java
+++ b/webtau-browser/src/main/java/com/twosigma/webtau/browser/expectation/PageElementCompareToHandler.java
@@ -24,7 +24,7 @@ import com.twosigma.webtau.expectation.equality.CompareToHandler;
 
 import java.util.List;
 
-import static com.twosigma.webtau.Ddjt.createActualPath;
+import static com.twosigma.webtau.WebTauCore.createActualPath;
 
 public class PageElementCompareToHandler implements CompareToHandler {
     @Override

--- a/webtau-browser/src/test/groovy/com/twosigma/webtau/browser/page/PageUrlTest.groovy
+++ b/webtau-browser/src/test/groovy/com/twosigma/webtau/browser/page/PageUrlTest.groovy
@@ -19,8 +19,7 @@ package com.twosigma.webtau.browser.page
 import com.twosigma.webtau.utils.ResourceUtils
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class PageUrlTest {
     private static def browser = [

--- a/webtau-cli-groovy/src/test/groovy/com/twosigma/webtau/cli/CliGroovyTest.groovy
+++ b/webtau-cli-groovy/src/test/groovy/com/twosigma/webtau/cli/CliGroovyTest.groovy
@@ -18,7 +18,7 @@ package com.twosigma.webtau.cli
 
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 import static com.twosigma.webtau.cli.Cli.cli
 import static com.twosigma.webtau.cli.CliTestUtils.supportedPlatformOnly
 

--- a/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliJavaTest.java
+++ b/webtau-cli/src/test/java/com/twosigma/webtau/cli/CliJavaTest.java
@@ -26,7 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 
-import static com.twosigma.webtau.Ddjt.*;
+import static com.twosigma.webtau.WebTauCore.*;
 import static com.twosigma.webtau.cli.Cli.cli;
 import static com.twosigma.webtau.cli.CliTestUtils.supportedPlatformOnly;
 

--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/expectation/equality/handlers/GroovyNullCompareToHandlerTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/expectation/equality/handlers/GroovyNullCompareToHandlerTest.groovy
@@ -19,10 +19,7 @@ package com.twosigma.webtau.data.expectation.equality.handlers
 import org.codehaus.groovy.runtime.NullObject
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.equal
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class GroovyNullCompareToHandlerTest {
     @Test

--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/render/TableDataRenderTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/render/TableDataRenderTest.groovy
@@ -18,7 +18,7 @@ package com.twosigma.webtau.data.render
 
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.table
+import static com.twosigma.webtau.WebTauCore.table
 import static org.junit.Assert.assertEquals
 
 class TableDataRenderTest {

--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/table/TableDataGroovyTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/data/table/TableDataGroovyTest.groovy
@@ -20,7 +20,7 @@ import org.junit.Test
 
 import java.time.LocalDate
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 import static com.twosigma.webtau.data.table.TableDataJavaTestValidations.validateAboveValue
 import static com.twosigma.webtau.data.table.TableDataJavaTestValidations.validateAboveValueWithMath
 import static com.twosigma.webtau.data.table.TableDataJavaTestValidations.validatePermute

--- a/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/groovy/ast/ShouldAstTransformationTest.groovy
+++ b/webtau-core-groovy/src/test/groovy/com/twosigma/webtau/groovy/ast/ShouldAstTransformationTest.groovy
@@ -27,8 +27,7 @@ import com.twosigma.webtau.expectation.equality.LessThanMatcher
 import com.twosigma.webtau.expectation.equality.LessThanOrEqualMatcher
 import com.twosigma.webtau.expectation.equality.NotEqualMatcher
 
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class ShouldAstTransformationTest extends GroovyTestCase {
     void testShouldNotTransformationOnNull() {

--- a/webtau-core/src/main/java/com/twosigma/webtau/Matchers.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/Matchers.java
@@ -67,7 +67,8 @@ public class Matchers {
     /**
      * Contain matcher
      * <pre>
-     * actual(value).should(contain(10));
+     * actual(collection).should(contain(10));
+     * actual(text).should(contain("hello"));
      * </pre>
      * @param expected value to be contained
      * @return matcher instance
@@ -77,9 +78,9 @@ public class Matchers {
     }
 
     /**
-     * Contain matcher. Alias to contain
+     * Containing matcher. Alias to contain
      * <pre>
-     * actual(value).should(containing(10));
+     * actual(collectionWithText).should(contain(containing("hello")));
      * </pre>
      * @param expected value to be contained
      * @return matcher instance

--- a/webtau-core/src/main/java/com/twosigma/webtau/Matchers.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/Matchers.java
@@ -1,0 +1,268 @@
+package com.twosigma.webtau;
+
+import com.twosigma.webtau.expectation.*;
+import com.twosigma.webtau.expectation.code.ThrowExceptionMatcher;
+import com.twosigma.webtau.expectation.contain.ContainMatcher;
+import com.twosigma.webtau.expectation.equality.*;
+
+import java.util.regex.Pattern;
+
+/**
+ * Convenient place to discover all the available matchers
+ */
+public class Matchers {
+    /**
+     * Starting point of a value matcher
+     * <pre>
+     * actual(value).should(beGreaterThan(10));
+     * actual(value).shouldNot(beGreaterThan(10));
+     * </pre>
+     * Note: In Groovy you can just do <code>value.should beGreaterThan(10)</code>
+     * @param actual value to assert against
+     * @return Object to chain a matcher against
+     */
+    public static ActualValueExpectations actual(Object actual) {
+        return new ActualValue(actual);
+    }
+
+    /**
+     * Starting point of a code matcher
+     * <pre>
+     * code(() -> {
+     *    businessLogic(-10);
+     * }).should(throwException(IllegalArgumentException.class, "negative are not allowed"));
+     * </pre>
+     *
+     * @param codeBlock code to match against
+     * @return Object to chain a matcher against
+     */
+    public static ActualCodeExpectations code(CodeBlock codeBlock) {
+        return new ActualCode(codeBlock);
+    }
+
+    /**
+     * Equal matcher
+     * <pre>
+     * actual(value).should(equal(10));
+     * </pre>
+     * @param expected value to be equal to
+     * @return matcher instance
+     */
+    public static EqualMatcher equal(Object expected) {
+        return new EqualMatcher(expected);
+    }
+
+    /**
+     * Not equal matcher
+     * <pre>
+     * actual(value).should(notEqual(10));
+     * </pre>
+     * @param expected value to not be equal to
+     * @return matcher instance
+     */
+    public static NotEqualMatcher notEqual(Object expected) {
+        return new NotEqualMatcher(expected);
+    }
+
+    /**
+     * Contain matcher
+     * <pre>
+     * actual(value).should(contain(10));
+     * </pre>
+     * @param expected value to be contained
+     * @return matcher instance
+     */
+    public static ContainMatcher contain(Object expected) {
+        return new ContainMatcher(expected);
+    }
+
+    /**
+     * Contain matcher. Alias to contain
+     * <pre>
+     * actual(value).should(containing(10));
+     * </pre>
+     * @param expected value to be contained
+     * @return matcher instance
+     */
+    public static ContainMatcher containing(Object expected) {
+        return new ContainMatcher(expected);
+    }
+
+    /**
+     * Greater than matcher
+     * <pre>
+     * actual(value).shouldBe(greaterThan(10));
+     * </pre>
+     * @param expected value to be greater than
+     * @return matcher instance
+     */
+    public static GreaterThanMatcher greaterThan(Object expected) {
+        return new GreaterThanMatcher(expected);
+    }
+
+    /**
+     * Greater than or equal matcher
+     * <pre>
+     * actual(value).shouldBe(greaterThanOrEqual(10));
+     * </pre>
+     * @param expected value to be greater than or equal
+     * @return matcher instance
+     */
+    public static GreaterThanOrEqualMatcher greaterThanOrEqual(Object expected) {
+        return new GreaterThanOrEqualMatcher(expected);
+    }
+
+    /**
+     * Less than matcher
+     * <pre>
+     * actual(value).shouldBe(lessThan(10));
+     * </pre>
+     * @param expected value to be less than
+     * @return matcher instance
+     */
+    public static LessThanMatcher lessThan(Object expected) {
+        return new LessThanMatcher(expected);
+    }
+
+    /**
+     * Less than or equal matcher
+     * <pre>
+     * actual(value).shouldBe(lessThanOrEqual(10));
+     * </pre>
+     * @param expected value to be less than
+     * @return matcher instance
+     */
+    public static LessThanOrEqualMatcher lessThanOrEqual(Object expected) {
+        return new LessThanOrEqualMatcher(expected);
+    }
+
+    /**
+     * Throw exception <code>code</code> matcher.
+     * <pre>
+     * code(() -> {
+     *     businessLogic(-10);
+     * }).should(throwException("negative are not allowed"));
+     * </pre>
+     * @see #code(CodeBlock)
+     *
+     * @param expectedMessage expected exception message
+     * @return matcher instance
+     */
+    public static ThrowExceptionMatcher throwException(String expectedMessage) {
+        return new ThrowExceptionMatcher(expectedMessage);
+    }
+
+    /**
+     * Throw exception <code>code</code> matcher.
+     * <pre>
+     * code(() -> {
+     *      businessLogic(-10);
+     * }).should(throwException(Pattern.compile("negative .* not allowed")));
+     * </pre>
+     * @see #code(CodeBlock)
+     *
+     * @param expectedMessageRegexp regular pattern to match expected exception message
+     * @return matcher instance
+     */
+    public static ThrowExceptionMatcher throwException(Pattern expectedMessageRegexp) {
+        return new ThrowExceptionMatcher(expectedMessageRegexp);
+    }
+
+    /**
+     * Throw exception <code>code</code> matcher.
+     * <pre>
+     * code(() -> {
+     *      businessLogic(-10);
+     * }).should(throwException(IllegalArgumentException.class));
+     * </pre>
+     * @see #code(CodeBlock)
+     *
+     * @param expectedClass expected exception class
+     * @return matcher instance
+     */
+    public static ThrowExceptionMatcher throwException(Class expectedClass) {
+        return new ThrowExceptionMatcher(expectedClass);
+    }
+
+    /**
+     * Throw exception <code>code</code> matcher.
+     * <pre>
+     * code(() -> {
+     *      businessLogic(-10);
+     * }).should(throwException(IllegalArgumentException.class, Pattern.compile("negative .* not allowed")));
+     * </pre>
+     * @see #code(CodeBlock)
+     *
+     * @param expectedClass expected exception class
+     * @param expectedMessageRegexp regular pattern to match expected exception message
+     * @return matcher instance
+     */
+    public static ThrowExceptionMatcher throwException(Class expectedClass, Pattern expectedMessageRegexp) {
+        return new ThrowExceptionMatcher(expectedClass, expectedMessageRegexp);
+    }
+
+    /**
+     * Throw exception <code>code</code> matcher.
+     * <pre>
+     * code(() -> {
+     *      businessLogic(-10);
+     * }).should(throwException(IllegalArgumentException.class, "negative are not allowed"));
+     * </pre>
+     * @see #code(CodeBlock)
+     *
+     * @param expectedClass expected exception class
+     * @param expectedMessage expected exception message
+     * @return matcher instance
+     */
+    public static ThrowExceptionMatcher throwException(Class expectedClass, String expectedMessage) {
+        return new ThrowExceptionMatcher(expectedClass, expectedMessage);
+    }
+
+    /**
+     * Deprecated. Instead use
+     * <pre>
+     * actual(value).shouldBe(greaterThan(10));
+     * </pre>
+     * @see #greaterThan(Object)
+     */
+    @Deprecated
+    public static GreaterThanMatcher beGreaterThan(Object expected) {
+        return greaterThan(expected);
+    }
+
+    /**
+     * Deprecated. Instead use
+     * <pre>
+     * actual(value).shouldBe(greaterThanOrEqual(10));
+     * </pre>
+     * @see #greaterThanOrEqual(Object)
+     */
+    @Deprecated
+    public static GreaterThanOrEqualMatcher beGreaterThanOrEqual(Object expected) {
+        return greaterThanOrEqual(expected);
+    }
+
+    /**
+     * Deprecated. Instead use
+     * <pre>
+     * actual(value).shouldBe(lessThan(10));
+     * </pre>
+     * @see #lessThan(Object)
+     */
+    @Deprecated
+    public static LessThanMatcher beLessThan(Object expected) {
+        return lessThan(expected);
+    }
+
+    /**
+     * Deprecated. Instead use
+     * <pre>
+     * actual(value).shouldBe(lessThanOrEqual(10));
+     * </pre>
+     * @see #lessThanOrEqual(Object)
+     */
+    @Deprecated
+    public static LessThanOrEqualMatcher beLessThanOrEqual(Object expected) {
+        return lessThanOrEqual(expected);
+    }
+}

--- a/webtau-core/src/main/java/com/twosigma/webtau/WebTauCore.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/WebTauCore.java
@@ -43,11 +43,9 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
- * Data Driven Java Testing
- * <p>
- * Convenient class for a single static * imports
+ * Convenient class for a single static * imports to have matchers and helper functions available for your test
  */
-public class Ddjt {
+public class WebTauCore extends Matchers {
     public static final TableDataCellValueGenFunctions cell = new TableDataCellValueGenFunctions();
 
     public static final TableDataUnderscore __ = TableDataUnderscore.INSTANCE;
@@ -72,84 +70,8 @@ public class Ddjt {
         return new MultiValue(atLeastOneValue, values);
     }
 
-    public static ActualValueExpectations actual(Object actual) {
-        return new ActualValue(actual);
-    }
-
-    public static ActualCodeExpectations code(CodeBlock codeBlock) {
-        return new ActualCode(codeBlock);
-    }
-
-    public static EqualMatcher equal(Object expected) {
-        return new EqualMatcher(expected);
-    }
-
-    public static NotEqualMatcher notEqual(Object expected) {
-        return new NotEqualMatcher(expected);
-    }
-
-    public static ContainMatcher contain(Object expected) {
-        return new ContainMatcher(expected);
-    }
-
-    public static ContainMatcher containing(Object expected) {
-        return new ContainMatcher(expected);
-    }
-
     public static <K, V> Map<K, V> aMapOf(Object... kvs) {
         return CollectionUtils.aMapOf(kvs);
-    }
-
-    public static GreaterThanMatcher beGreaterThan(Object expected) {
-        return new GreaterThanMatcher(expected);
-    }
-
-    public static GreaterThanOrEqualMatcher beGreaterThanOrEqual(Object expected) {
-        return new GreaterThanOrEqualMatcher(expected);
-    }
-
-    public static LessThanMatcher beLessThan(Object expected) {
-        return new LessThanMatcher(expected);
-    }
-
-    public static LessThanOrEqualMatcher beLessThanOrEqual(Object expected) {
-        return new LessThanOrEqualMatcher(expected);
-    }
-
-    public static GreaterThanMatcher greaterThan(Object expected) {
-        return beGreaterThan(expected);
-    }
-
-    public static GreaterThanOrEqualMatcher greaterThanOrEqual(Object expected) {
-        return beGreaterThanOrEqual(expected);
-    }
-
-    public static LessThanMatcher lessThan(Object expected) {
-        return beLessThan(expected);
-    }
-
-    public static LessThanOrEqualMatcher lessThanOrEqual(Object expected) {
-        return beLessThanOrEqual(expected);
-    }
-
-    public static ThrowExceptionMatcher throwException(String expectedMessage) {
-        return new ThrowExceptionMatcher(expectedMessage);
-    }
-
-    public static ThrowExceptionMatcher throwException(Pattern expectedMessageRegexp) {
-        return new ThrowExceptionMatcher(expectedMessageRegexp);
-    }
-
-    public static ThrowExceptionMatcher throwException(Class expectedClass) {
-        return new ThrowExceptionMatcher(expectedClass);
-    }
-
-    public static ThrowExceptionMatcher throwException(Class expectedClass, Pattern expectedMessageRegexp) {
-        return new ThrowExceptionMatcher(expectedClass, expectedMessageRegexp);
-    }
-
-    public static ThrowExceptionMatcher throwException(Class expectedClass, String expectedMessage) {
-        return new ThrowExceptionMatcher(expectedClass, expectedMessage);
     }
 
     public static ActualPath createActualPath(String path) {

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFunctions.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/autogen/TableDataCellValueGenFunctions.java
@@ -16,8 +16,10 @@
 
 package com.twosigma.webtau.data.table.autogen;
 
+import com.twosigma.webtau.WebTauCore;
+
 /**
- * @see com.twosigma.webtau.Ddjt#cell
+ * @see WebTauCore#cell
  */
 public class TableDataCellValueGenFunctions {
     public final TableDataCellValueGenerator<?> above = TableDataCellAbove.generator;

--- a/webtau-core/src/main/java/com/twosigma/webtau/data/table/comparison/TableDataComparison.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/data/table/comparison/TableDataComparison.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static com.twosigma.webtau.Ddjt.createActualPath;
+import static com.twosigma.webtau.WebTauCore.createActualPath;
 import static java.util.stream.Collectors.toSet;
 
 public class TableDataComparison {

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/ActualValue.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/ActualValue.java
@@ -21,7 +21,7 @@ import com.twosigma.webtau.expectation.timer.ExpectationTimer;
 
 import java.util.function.Function;
 
-import static com.twosigma.webtau.Ddjt.createActualPath;
+import static com.twosigma.webtau.WebTauCore.createActualPath;
 
 public class ActualValue implements ActualValueExpectations {
     private Object actual;

--- a/webtau-core/src/main/java/com/twosigma/webtau/expectation/code/ThrowExceptionMatcher.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/expectation/code/ThrowExceptionMatcher.java
@@ -16,7 +16,7 @@
 
 package com.twosigma.webtau.expectation.code;
 
-import static com.twosigma.webtau.Ddjt.createActualPath;
+import static com.twosigma.webtau.WebTauCore.createActualPath;
 
 import com.twosigma.webtau.expectation.CodeBlock;
 import com.twosigma.webtau.expectation.CodeMatcher;

--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/ValueMatcherExpectationSteps.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/ValueMatcherExpectationSteps.java
@@ -19,7 +19,7 @@ package com.twosigma.webtau.reporter;
 import com.twosigma.webtau.expectation.ValueMatcher;
 import com.twosigma.webtau.expectation.timer.ExpectationTimer;
 
-import static com.twosigma.webtau.Ddjt.actual;
+import static com.twosigma.webtau.WebTauCore.actual;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.TO;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.action;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.matcher;

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/RecordTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/data/table/RecordTest.groovy
@@ -19,7 +19,7 @@ package com.twosigma.webtau.data.table
 import com.twosigma.webtau.data.table.header.Header
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 
 class RecordTest {
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/ActualValueTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/ActualValueTest.groovy
@@ -22,8 +22,7 @@ import com.twosigma.webtau.expectation.timer.DummyExpectationTimer
 import org.junit.Before
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.WebTauCore.*
 
 class ActualValueTest {
     LiveValue liveValue

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/code/ThrowExceptionMatcherGroovyTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/code/ThrowExceptionMatcherGroovyTest.groovy
@@ -22,8 +22,7 @@ import org.junit.rules.ExpectedException
 
 import java.lang.reflect.UndeclaredThrowableException
 
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class ThrowExceptionMatcherGroovyTest {
     @Rule

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/contain/ContainMatcherTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/contain/ContainMatcherTest.groovy
@@ -18,10 +18,7 @@ package com.twosigma.webtau.expectation.contain
 
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.contain
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class ContainMatcherTest {
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/contain/handlers/IterableContainHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/contain/handlers/IterableContainHandlerTest.groovy
@@ -21,11 +21,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.contain
-import static com.twosigma.webtau.Ddjt.createActualPath
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class IterableContainHandlerTest {
     private ContainAnalyzer analyzer

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/contain/handlers/StringContainHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/contain/handlers/StringContainHandlerTest.groovy
@@ -21,7 +21,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.createActualPath
+import static com.twosigma.webtau.WebTauCore.*
 
 class StringContainHandlerTest {
     private ContainAnalyzer analyzer

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/ActualPathMessageTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/ActualPathMessageTest.groovy
@@ -19,7 +19,7 @@ package com.twosigma.webtau.expectation.equality
 import org.junit.Assert
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.createActualPath
+import static com.twosigma.webtau.WebTauCore.createActualPath
 
 class ActualPathMessageTest {
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/AnyCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/AnyCompareToHandlerTest.groovy
@@ -18,106 +18,102 @@ package com.twosigma.webtau.expectation.equality.handlers
 
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.beGreaterThan
-import static com.twosigma.webtau.Ddjt.beGreaterThanOrEqual
-import static com.twosigma.webtau.Ddjt.beLessThan
-import static com.twosigma.webtau.Ddjt.beLessThanOrEqual
+import static com.twosigma.webtau.WebTauCore.*
 
 class AnyCompareToHandlerTest {
     def expected = 10
 
     @Test
     void "positive greater than match"() {
-        actual(expected).should(beGreaterThan(expected - 1))
+        actual(expected).shouldBe(greaterThan(expected - 1))
     }
 
     @Test
     void "positive greater than or equal to match"() {
-        actual(expected).should(beGreaterThanOrEqual(expected - 1))
-        actual(expected).should(beGreaterThanOrEqual(expected))
+        actual(expected).shouldBe(greaterThanOrEqual(expected - 1))
+        actual(expected).shouldBe(greaterThanOrEqual(expected))
     }
 
     @Test
     void "positive less than match"() {
-        actual(expected).should(beLessThan(expected + 1))
+        actual(expected).shouldBe(lessThan(expected + 1))
     }
 
     @Test
     void "positive less than or equal to match"() {
-        actual(expected).should(beLessThanOrEqual(expected + 1))
-        actual(expected).should(beLessThanOrEqual(expected))
+        actual(expected).shouldBe(lessThanOrEqual(expected + 1))
+        actual(expected).shouldBe(lessThanOrEqual(expected))
     }
 
     @Test(expected = AssertionError)
     void "positive greater than mismatch"() {
-        actual(expected).should(beGreaterThan(expected))
+        actual(expected).shouldBe(greaterThan(expected))
     }
 
     @Test(expected = AssertionError)
     void "positive greater than or equal to mismatch"() {
-        actual(expected).should(beGreaterThanOrEqual(expected + 1))
+        actual(expected).shouldBe(greaterThanOrEqual(expected + 1))
     }
 
     @Test(expected = AssertionError)
     void "positive less than mismatch"() {
-        actual(expected).should(beLessThan(expected))
+        actual(expected).shouldBe(lessThan(expected))
     }
 
     @Test(expected = AssertionError)
     void "positive less than or equal to mismatch"() {
-        actual(expected).should(beLessThanOrEqual(expected - 1))
+        actual(expected).shouldBe(lessThanOrEqual(expected - 1))
     }
 
     @Test
     void "negative greater than match"() {
-        actual(expected).shouldNot(beGreaterThan(expected))
-        actual(expected).shouldNot(beGreaterThan(expected + 1))
+        actual(expected).shouldNotBe(greaterThan(expected))
+        actual(expected).shouldNotBe(greaterThan(expected + 1))
     }
 
     @Test
     void "negative greater than or equal to match"() {
-        actual(expected).shouldNot(beGreaterThanOrEqual(expected + 1))
+        actual(expected).shouldNotBe(greaterThanOrEqual(expected + 1))
     }
 
     @Test
     void "negative less than match"() {
-        actual(expected).shouldNot(beLessThan(expected))
-        actual(expected).shouldNot(beLessThan(expected - 1))
+        actual(expected).shouldNotBe(lessThan(expected))
+        actual(expected).shouldNotBe(lessThan(expected - 1))
     }
 
     @Test
     void "negative less than or equal to match"() {
-        actual(expected).shouldNot(beLessThanOrEqual(expected - 1))
+        actual(expected).shouldNotBe(lessThanOrEqual(expected - 1))
     }
 
     @Test(expected = AssertionError)
     void "negative greater than mismatch"() {
-        actual(expected).shouldNot(beGreaterThan(expected - 1))
+        actual(expected).shouldNotBe(greaterThan(expected - 1))
     }
 
     @Test(expected = AssertionError)
     void "negative greater than or equal to mismatch: equal"() {
-        actual(expected).shouldNot(beGreaterThanOrEqual(expected))
+        actual(expected).shouldNotBe(greaterThanOrEqual(expected))
     }
 
     @Test(expected = AssertionError)
     void "negative greater than or equal to mismatch: greater"() {
-        actual(expected).shouldNot(beGreaterThanOrEqual(expected - 1))
+        actual(expected).shouldNotBe(greaterThanOrEqual(expected - 1))
     }
 
     @Test(expected = AssertionError)
     void "negative less than mismatch"() {
-        actual(expected).shouldNot(beLessThan(expected + 1))
+        actual(expected).shouldNotBe(lessThan(expected + 1))
     }
 
     @Test(expected = AssertionError)
     void "negative less than or equal to mismatch: equal"() {
-        actual(expected).shouldNot(beLessThanOrEqual(expected))
+        actual(expected).shouldNotBe(lessThanOrEqual(expected))
     }
 
     @Test(expected = AssertionError)
     void "negative less than or equal to mismatch: greater"() {
-        actual(expected).shouldNot(beLessThanOrEqual(expected + 1))
+        actual(expected).shouldNotBe(lessThanOrEqual(expected + 1))
     }
 }

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/ArrayAndIterableCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/ArrayAndIterableCompareToHandlerTest.groovy
@@ -2,8 +2,7 @@ package com.twosigma.webtau.expectation.equality.handlers
 
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.WebTauCore.*
 
 class ArrayAndIterableCompareToHandlerTest {
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/ByteArrayCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/ByteArrayCompareToHandlerTest.groovy
@@ -20,7 +20,7 @@ import com.twosigma.webtau.expectation.ActualPath
 import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.createActualPath
+import static com.twosigma.webtau.WebTauCore.createActualPath
 import static org.junit.Assert.assertEquals
 
 class ByteArrayCompareToHandlerTest {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/DateAndStringCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/DateAndStringCompareToHandlerTest.groovy
@@ -22,11 +22,7 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.beGreaterThan
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.equal
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class DateAndStringCompareToHandlerTest {
     @Test
@@ -39,7 +35,7 @@ class DateAndStringCompareToHandlerTest {
 
     @Test
     void "actual local date string greater than expected local date instance"() {
-        actual("2018-06-10").should(beGreaterThan(LocalDate.of(2018, 6, 9)))
+        actual("2018-06-10").shouldBe(greaterThan(LocalDate.of(2018, 6, 9)))
     }
 
     @Test
@@ -59,13 +55,13 @@ class DateAndStringCompareToHandlerTest {
 
     @Test
     void "actual zoned date time string greater than expected local date instance"() {
-        actual("2018-01-02T00:00:00Z").should(beGreaterThan(LocalDate.of(2018, 1, 1)))
+        actual("2018-01-02T00:00:00Z").shouldBe(greaterThan(LocalDate.of(2018, 1, 1)))
     }
 
     @Test
     void "actual zoned date time string equals expected local date instance, when should be greater"() {
         code {
-            actual("2018-01-01T00:00:00Z").should(beGreaterThan(LocalDate.of(2018, 1, 1)))
+            actual("2018-01-01T00:00:00Z").shouldBe(greaterThan(LocalDate.of(2018, 1, 1)))
         } should throwException("\nmismatches:\n\n" +
             "[value]:   actual: 2018-01-01T00:00Z <java.time.ZonedDateTime>\n" +
             "         expected: greater than 2018-01-01 <java.time.LocalDate>")
@@ -73,7 +69,7 @@ class DateAndStringCompareToHandlerTest {
 
     @Test
     void "actual zoned date time string greater than expected zoned date time instance"() {
-        actual("2018-01-02T10:00:00-01:00:00").should(beGreaterThan(
+        actual("2018-01-02T10:00:00-01:00:00").shouldBe(greaterThan(
             ZonedDateTime.of(2018, 1, 2, 10, 0, 0, 0, ZoneId.of("UTC"))))
     }
 
@@ -86,7 +82,7 @@ class DateAndStringCompareToHandlerTest {
     @Test
     void "actual zoned date time string less than expected zoned date time instance, when should be greater"() {
         code {
-            actual("2018-01-02T10:00:00+01:00:00").should(beGreaterThan(
+            actual("2018-01-02T10:00:00+01:00:00").shouldBe(greaterThan(
                 ZonedDateTime.of(2018, 1, 2, 10, 0, 0, 0, ZoneId.of("UTC"))))
         } should throwException("\nmismatches:\n" +
             "\n" +

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/HandlerMessagesTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/HandlerMessagesTest.groovy
@@ -6,11 +6,7 @@ import org.junit.Test
 import java.time.LocalDate
 import java.util.stream.Stream
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.equal
-import static com.twosigma.webtau.Ddjt.lessThan
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class HandlerMessagesTest {
     // AnyCompareTo messages

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/IterableAndTableDataCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/IterableAndTableDataCompareToHandlerTest.groovy
@@ -19,10 +19,7 @@ package com.twosigma.webtau.expectation.equality.handlers
 import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.createActualPath
-import static com.twosigma.webtau.Ddjt.equal
-import static com.twosigma.webtau.Ddjt.table
+import static com.twosigma.webtau.WebTauCore.*
 
 class IterableAndTableDataCompareToHandlerTest {
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/IterableCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/IterableCompareToHandlerTest.groovy
@@ -20,9 +20,7 @@ import com.twosigma.webtau.expectation.ActualPath
 import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.createActualPath
-import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.WebTauCore.*
 import static com.twosigma.webtau.expectation.equality.CompareToComparator.AssertionMode
 import static org.junit.Assert.assertEquals
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/LiveValueCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/LiveValueCompareToHandlerTest.groovy
@@ -19,8 +19,7 @@ package com.twosigma.webtau.expectation.equality.handlers
 import com.twosigma.webtau.data.DummyLiveValue
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.WebTauCore.*
 
 class LiveValueCompareToHandlerTest {
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/MapAndBeanCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/MapAndBeanCompareToHandlerTest.groovy
@@ -20,7 +20,7 @@ import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Before
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.createActualPath
+import static com.twosigma.webtau.WebTauCore.createActualPath
 import static org.junit.Assert.assertEquals
 
 class MapAndBeanCompareToHandlerTest {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/MapsCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/MapsCompareToHandlerTest.groovy
@@ -20,7 +20,7 @@ import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Before
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.createActualPath
+import static com.twosigma.webtau.WebTauCore.createActualPath
 import static com.twosigma.webtau.expectation.equality.CompareToComparator.AssertionMode
 import static org.junit.Assert.assertEquals
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NullCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NullCompareToHandlerTest.groovy
@@ -19,7 +19,7 @@ package com.twosigma.webtau.expectation.equality.handlers
 import com.twosigma.webtau.expectation.ValueMatcher
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 
 class NullCompareToHandlerTest {
     @Test
@@ -56,8 +56,8 @@ class NullCompareToHandlerTest {
 
     @Test
     void "null is greater-than-or-equal and less-than-or-equal than null"() {
-        actual(null).should(beGreaterThanOrEqual(null))
-        actual(null).should(beLessThanOrEqual(null))
+        actual(null).shouldBe(greaterThanOrEqual(null))
+        actual(null).shouldBe(lessThanOrEqual(null))
     }
 
     @Test
@@ -69,11 +69,11 @@ class NullCompareToHandlerTest {
 
         }
 
-        expect(beGreaterThan(10), "expected: greater than 10")
-        expect(beGreaterThanOrEqual(10), "expected: greater than or equal to 10")
+        expect(greaterThan(10), "expected: greater than 10")
+        expect(greaterThanOrEqual(10), "expected: greater than or equal to 10")
 
-        expect(beLessThan(10), "expected: less than 10")
-        expect(beLessThanOrEqual(10), "expected: less than or equal to 10")
+        expect(lessThan(10), "expected: less than 10")
+        expect(lessThanOrEqual(10), "expected: less than or equal to 10")
     }
 
     @Test
@@ -85,10 +85,10 @@ class NullCompareToHandlerTest {
 
         }
 
-        expect(beGreaterThan(null), "expected: greater than null")
-        expect(beGreaterThanOrEqual(null), "expected: greater than or equal to null")
+        expect(greaterThan(null), "expected: greater than null")
+        expect(greaterThanOrEqual(null), "expected: greater than or equal to null")
 
-        expect(beLessThan(null), "expected: less than null")
-        expect(beLessThanOrEqual(null), "expected: less than or equal to null")
+        expect(lessThan(null), "expected: less than null")
+        expect(lessThanOrEqual(null), "expected: less than or equal to null")
     }
 }

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NumberAndStringCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NumberAndStringCompareToHandlerTest.groovy
@@ -18,7 +18,7 @@ package com.twosigma.webtau.expectation.equality.handlers
 
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 
 class NumberAndStringCompareToHandlerTest {
     @Test
@@ -38,7 +38,7 @@ class NumberAndStringCompareToHandlerTest {
 
     @Test
     void "automatically convert string to a number for greater-less comparison"() {
-        actual("100.54").should(beGreaterThan(30))
+        actual("100.54").shouldBe(greaterThan(30))
     }
 
     @Test
@@ -51,19 +51,19 @@ class NumberAndStringCompareToHandlerTest {
     @Test
     void "non parsable string should not be greater or less a give number"() {
         code {
-            actual("abc").should(beGreaterThan(100))
+            actual("abc").shouldBe(greaterThan(100))
         } should throwException(AssertionError)
 
         code {
-            actual("abc").should(beLessThan(100))
+            actual("abc").shouldBe(lessThan(100))
         } should throwException(AssertionError)
 
         code {
-            actual("abc").should(beGreaterThanOrEqual(100))
+            actual("abc").shouldBe(greaterThanOrEqual(100))
         } should throwException(AssertionError)
 
         code {
-            actual("abc").should(beLessThanOrEqual(100))
+            actual("abc").shouldBe(lessThanOrEqual(100))
         } should throwException(AssertionError)
     }
 }

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NumbersCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/NumbersCompareToHandlerTest.groovy
@@ -20,12 +20,7 @@ import com.twosigma.webtau.expectation.ActualPath
 import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.beGreaterThanOrEqual
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.createActualPath
-import static com.twosigma.webtau.Ddjt.equal
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 import static org.junit.Assert.assertEquals
 
 class NumbersCompareToHandlerTest {
@@ -86,14 +81,14 @@ class NumbersCompareToHandlerTest {
     @Test
     void "handler is linked"() {
         actual(10.0).should(equal(10))
-        actual(10.0).should(beGreaterThanOrEqual(8l))
+        actual(10.0).shouldBe(greaterThanOrEqual(8l))
 
         code {
             actual(10.0).should(equal(9))
         } should throwException(AssertionError, ~/expected: 9/)
 
         code {
-            actual(10.0).should(beGreaterThanOrEqual(11))
+            actual(10.0).shouldBe(greaterThanOrEqual(11))
         } should throwException(AssertionError, ~/expected: greater than or equal to 11/)
     }
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/RegexpEqualCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/RegexpEqualCompareToHandlerTest.groovy
@@ -18,8 +18,7 @@ package com.twosigma.webtau.expectation.equality.handlers
 
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.WebTauCore.*
 
 class RegexpEqualCompareToHandlerTest {
     @Test

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/SetCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/SetCompareToHandlerTest.groovy
@@ -20,7 +20,7 @@ import com.twosigma.webtau.expectation.ActualPath
 import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 import static com.twosigma.webtau.expectation.equality.CompareToComparator.AssertionMode.*
 import static org.junit.Assert.assertEquals
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/StringCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/StringCompareToHandlerTest.groovy
@@ -19,9 +19,7 @@ package com.twosigma.webtau.expectation.equality.handlers
 import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.createActualPath
-import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.WebTauCore.*
 import static org.junit.Assert.assertEquals
 
 class StringCompareToHandlerTest {

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/TraceableValueCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/TraceableValueCompareToHandlerTest.groovy
@@ -21,14 +21,7 @@ import com.twosigma.webtau.data.traceable.TraceableValue
 import org.junit.Before
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.beGreaterThan
-import static com.twosigma.webtau.Ddjt.beGreaterThanOrEqual
-import static com.twosigma.webtau.Ddjt.beLessThan
-import static com.twosigma.webtau.Ddjt.beLessThanOrEqual
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.equal
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class TraceableValueCompareToHandlerTest {
     def nonMatchingValue = 100
@@ -78,38 +71,38 @@ class TraceableValueCompareToHandlerTest {
 
     @Test
     void "mark value as fuzzy passed when matches during greater than"() {
-        actual(traceableValue).should(beGreaterThan(traceableValue.value - 1))
+        actual(traceableValue).shouldBe(greaterThan(traceableValue.value - 1))
         assert traceableValue.checkLevel == CheckLevel.FuzzyPassed
     }
 
     @Test
     void "mark value as fuzzy passed when matches during greater than or equal"() {
-        actual(traceableValue).should(beGreaterThanOrEqual(traceableValue.value))
+        actual(traceableValue).shouldBe(greaterThanOrEqual(traceableValue.value))
         assert traceableValue.checkLevel == CheckLevel.FuzzyPassed
     }
 
     @Test
     void "mark value as fuzzy passed when matches during less than"() {
-        actual(traceableValue).should(beLessThan(traceableValue.value + 1))
+        actual(traceableValue).shouldBe(lessThan(traceableValue.value + 1))
         assert traceableValue.checkLevel == CheckLevel.FuzzyPassed
     }
 
     @Test
     void "mark value as fuzzy passed when matches during less than or equal"() {
-        actual(traceableValue).should(beLessThanOrEqual(traceableValue.value))
+        actual(traceableValue).shouldBe(lessThanOrEqual(traceableValue.value))
         assert traceableValue.checkLevel == CheckLevel.FuzzyPassed
     }
 
     @Test
     void "mark value as fuzzy passed when matches during not less than or equal"() {
-        actual(traceableValue).shouldNot(beLessThanOrEqual(traceableValue.value - 1))
+        actual(traceableValue).shouldNotBe(lessThanOrEqual(traceableValue.value - 1))
         assert traceableValue.checkLevel == CheckLevel.FuzzyPassed
     }
 
     @Test
     void "mark value as explicitly failed when fails during less than"() {
         code {
-            actual(traceableValue).should(beLessThan(traceableValue.value - 1))
+            actual(traceableValue).shouldBe(lessThan(traceableValue.value - 1))
         } should throwException(AssertionError)
 
         assert traceableValue.checkLevel == CheckLevel.ExplicitFailed
@@ -118,7 +111,7 @@ class TraceableValueCompareToHandlerTest {
     @Test
     void "mark value as explicitly failed when fails during less than or equal"() {
         code {
-            actual(traceableValue).should(beLessThanOrEqual(traceableValue.value - 1))
+            actual(traceableValue).shouldBe(lessThanOrEqual(traceableValue.value - 1))
         } should throwException(AssertionError)
 
         assert traceableValue.checkLevel == CheckLevel.ExplicitFailed
@@ -127,7 +120,7 @@ class TraceableValueCompareToHandlerTest {
     @Test
     void "mark value as explicitly failed when fails during greater than"() {
         code {
-            actual(traceableValue).should(beGreaterThan(traceableValue.value + 1))
+            actual(traceableValue).shouldBe(greaterThan(traceableValue.value + 1))
         } should throwException(AssertionError)
 
         assert traceableValue.checkLevel == CheckLevel.ExplicitFailed
@@ -136,7 +129,7 @@ class TraceableValueCompareToHandlerTest {
     @Test
     void "mark value as explicitly failed when fails during greater than or equal"() {
         code {
-            actual(traceableValue).should(beGreaterThanOrEqual(traceableValue.value + 1))
+            actual(traceableValue).shouldBe(greaterThanOrEqual(traceableValue.value + 1))
         } should throwException(AssertionError)
 
         assert traceableValue.checkLevel == CheckLevel.ExplicitFailed
@@ -145,7 +138,7 @@ class TraceableValueCompareToHandlerTest {
     @Test
     void "mark value as explicitly failed when fails during not greater than"() {
         code {
-            actual(traceableValue).shouldNot(beGreaterThan(traceableValue.value - 1))
+            actual(traceableValue).shouldNotBe(greaterThan(traceableValue.value - 1))
         } should throwException(AssertionError)
 
         assert traceableValue.checkLevel == CheckLevel.ExplicitFailed

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/ValueMatcherCompareToHandlerTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/expectation/equality/handlers/ValueMatcherCompareToHandlerTest.groovy
@@ -21,14 +21,7 @@ import com.twosigma.webtau.expectation.ValueMatcher
 import com.twosigma.webtau.expectation.equality.CompareToComparator
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.beGreaterThan
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.contain
-import static com.twosigma.webtau.Ddjt.containing
-import static com.twosigma.webtau.Ddjt.createActualPath
-import static com.twosigma.webtau.Ddjt.greaterThan
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 import static org.junit.Assert.assertEquals
 
 class ValueMatcherCompareToHandlerTest {
@@ -37,7 +30,7 @@ class ValueMatcherCompareToHandlerTest {
     @Test
     void "handles expected as ValueMatcher"() {
         def handler = new ValueMatcherCompareToHandler()
-        assert handler.handleEquality(100, beGreaterThan(10))
+        assert handler.handleEquality(100, greaterThan(10))
         assert !handler.handleEquality(100, 200)
     }
 

--- a/webtau-core/src/test/groovy/com/twosigma/webtau/reporter/ConsoleStepReporterTest.groovy
+++ b/webtau-core/src/test/groovy/com/twosigma/webtau/reporter/ConsoleStepReporterTest.groovy
@@ -26,8 +26,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.action
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.matcher
 import static org.junit.Assert.assertEquals

--- a/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
-import static com.twosigma.webtau.Ddjt.*;
+import static com.twosigma.webtau.WebTauCore.*;
 import static com.twosigma.webtau.data.table.TableDataJavaTestValidations.*;
 
 public class TableDataJavaTest {

--- a/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaTestValidations.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/data/table/TableDataJavaTestValidations.java
@@ -18,9 +18,7 @@ package com.twosigma.webtau.data.table;
 
 import java.time.LocalDate;
 
-import static com.twosigma.webtau.Ddjt.aMapOf;
-import static com.twosigma.webtau.Ddjt.actual;
-import static com.twosigma.webtau.Ddjt.equal;
+import static com.twosigma.webtau.WebTauCore.*;
 
 public class TableDataJavaTestValidations {
     public static void validateSimpleTableData(TableData tableData) {

--- a/webtau-core/src/test/java/com/twosigma/webtau/documentation/MarginCalculatorWithTableDataTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/documentation/MarginCalculatorWithTableDataTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static com.twosigma.webtau.Ddjt.*;
+import static com.twosigma.webtau.WebTauCore.*;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 

--- a/webtau-core/src/test/java/com/twosigma/webtau/documentation/PeopleDaoTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/documentation/PeopleDaoTest.java
@@ -19,9 +19,7 @@ package com.twosigma.webtau.documentation;
 import com.twosigma.webtau.data.table.TableData;
 import org.junit.Test;
 
-import static com.twosigma.webtau.Ddjt.actual;
-import static com.twosigma.webtau.Ddjt.equal;
-import static com.twosigma.webtau.Ddjt.table;
+import static com.twosigma.webtau.WebTauCore.*;
 
 public class PeopleDaoTest {
     private PeopleDao dao = new PeopleDao();

--- a/webtau-core/src/test/java/com/twosigma/webtau/documentation/PeopleManagementTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/documentation/PeopleManagementTest.java
@@ -21,9 +21,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static com.twosigma.webtau.Ddjt.actual;
-import static com.twosigma.webtau.Ddjt.equal;
-import static com.twosigma.webtau.Ddjt.table;
+import static com.twosigma.webtau.WebTauCore.*;
 import static java.util.stream.Collectors.toList;
 
 public class PeopleManagementTest {

--- a/webtau-core/src/test/java/com/twosigma/webtau/expectation/code/ThrowExceptionMatcherTest.java
+++ b/webtau-core/src/test/java/com/twosigma/webtau/expectation/code/ThrowExceptionMatcherTest.java
@@ -20,12 +20,16 @@ import org.junit.Test;
 
 import java.util.regex.Pattern;
 
-import static com.twosigma.webtau.Ddjt.code;
-import static com.twosigma.webtau.Ddjt.throwException;
+import static com.twosigma.webtau.WebTauCore.code;
+import static com.twosigma.webtau.WebTauCore.throwException;
 
 public class ThrowExceptionMatcherTest {
     @Test
     public void examples() {
+        code(() -> {
+            businessLogic(-10);
+        }).should(throwException("negative are not allowed"));
+
         code(() -> {
             businessLogic(-10);
         }).should(throwException(IllegalArgumentException.class, "negative are not allowed"));

--- a/webtau-docs/webtau/reference/table-data.md
+++ b/webtau-docs/webtau/reference/table-data.md
@@ -9,7 +9,8 @@ Groovy:
 Java:
 :include-java: com/twosigma/webtau/data/table/TableDataJavaTest.java {entry: "createTableDataInOneGo", bodyOnly: true, removeReturn: true, removeSemicolon: true}
 
- Note: The example above assumes `import static com.twosigma.webtau.Ddjt.*`. Additionally `Ddjt` has header-separating 
+ Note: The example above assumes `import static com.twosigma.webtau.WebTauCore.*` or `import static com.twosigma.webtau.WebTauDsl.*`.
+Additionally `WebTauCore` has header-separating 
 lines defined using underscores `___` of various lengths, which you can optionally use for aesthetics. 
 ```
 

--- a/webtau-feature-testing/examples/scenarios/ui/greaterThan.groovy
+++ b/webtau-feature-testing/examples/scenarios/ui/greaterThan.groovy
@@ -1,13 +1,12 @@
 package scenarios.ui
 
-import static com.twosigma.webtau.WebTauDsl.beGreaterThan
-import static com.twosigma.webtau.WebTauGroovyDsl.scenario
-import static pages.Pages.getSearch
+import static com.twosigma.webtau.WebTauGroovyDsl.*
+import static pages.Pages.*
 
 scenario("greater than matcher") {
     search.open()
 
     search.submit(query: "search this")
-    search.numberOfResults.waitTo beGreaterThan(1L)
+    search.numberOfResults.waitToBe greaterThan(1L)
 }
 

--- a/webtau-groovy-ast/src/main/groovy/com/twosigma/webtau/groovy/ast/ShouldAstCodeTransformer.groovy
+++ b/webtau-groovy-ast/src/main/groovy/com/twosigma/webtau/groovy/ast/ShouldAstCodeTransformer.groovy
@@ -16,7 +16,7 @@
 
 package com.twosigma.webtau.groovy.ast
 
-import com.twosigma.webtau.Ddjt
+import com.twosigma.webtau.WebTauCore
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import org.codehaus.groovy.ast.ClassCodeExpressionTransformer
@@ -89,7 +89,7 @@ class ShouldAstCodeTransformer extends ClassCodeExpressionTransformer {
                                                                     Expression rightExpression) {
         new MethodCallExpression(leftExpression.objectExpression, leftExpression.property,
             new ArgumentListExpression(new StaticMethodCallExpression(
-                new ClassNode(Ddjt), matcherMethodForOperation(operationText), rightExpression)))
+                new ClassNode(WebTauCore), matcherMethodForOperation(operationText), rightExpression)))
     }
 
     static String matcherMethodForOperation(String operationText) {

--- a/webtau-groovy/src/test/groovy/com/twosigma/webtau/cfg/WebTauGroovyFileConfigHandlerTest.groovy
+++ b/webtau-groovy/src/test/groovy/com/twosigma/webtau/cfg/WebTauGroovyFileConfigHandlerTest.groovy
@@ -22,8 +22,7 @@ import org.junit.Test
 
 import java.nio.file.Files
 
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class WebTauGroovyFileConfigHandlerTest {
     @Test

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/HttpGroovyTest.groovy
@@ -39,7 +39,7 @@ import java.time.ZonedDateTime
 import java.util.function.Consumer
 import java.util.stream.Collectors
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 import static com.twosigma.webtau.cfg.WebTauConfig.cfg
 import static com.twosigma.webtau.http.Http.http
 import static org.junit.Assert.assertFalse

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.zip.GZIPInputStream;
 
-import static com.twosigma.webtau.Ddjt.equal;
+import static com.twosigma.webtau.WebTauCore.equal;
 import static com.twosigma.webtau.cfg.WebTauConfig.getCfg;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.action;
 import static com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder.urlValue;

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/datanode/DataNode.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/datanode/DataNode.java
@@ -24,7 +24,7 @@ import com.twosigma.webtau.expectation.equality.CompareToResult;
 import java.util.List;
 import java.util.Map;
 
-import static com.twosigma.webtau.Ddjt.createActualPath;
+import static com.twosigma.webtau.WebTauCore.createActualPath;
 
 public interface DataNode extends DataNodeExpectations, Comparable, Iterable<DataNode> {
     DataNodeId id();

--- a/webtau-http/src/test/groovy/com/twosigma/webtau/http/datanode/DataNodeListContainHandlerTest.groovy
+++ b/webtau-http/src/test/groovy/com/twosigma/webtau/http/datanode/DataNodeListContainHandlerTest.groovy
@@ -18,9 +18,7 @@ package com.twosigma.webtau.http.datanode
 
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.contain
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 import static com.twosigma.webtau.data.traceable.CheckLevel.ExplicitFailed
 import static com.twosigma.webtau.data.traceable.CheckLevel.ExplicitPassed
 import static com.twosigma.webtau.data.traceable.CheckLevel.FuzzyPassed

--- a/webtau-http/src/test/groovy/com/twosigma/webtau/http/datanode/StructuredDataNodeTest.groovy
+++ b/webtau-http/src/test/groovy/com/twosigma/webtau/http/datanode/StructuredDataNodeTest.groovy
@@ -20,9 +20,7 @@ import com.twosigma.webtau.data.traceable.CheckLevel
 import com.twosigma.webtau.data.traceable.TraceableValue
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.equal
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class StructuredDataNodeTest {
     @Test

--- a/webtau-http/src/test/groovy/com/twosigma/webtau/http/render/DataNodeAnsiPrinterTest.groovy
+++ b/webtau-http/src/test/groovy/com/twosigma/webtau/http/render/DataNodeAnsiPrinterTest.groovy
@@ -28,7 +28,7 @@ import org.junit.Assert
 import org.junit.BeforeClass
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.WebTauCore.equal
 
 class DataNodeAnsiPrinterTest {
     private static def ansiConsoleOutput = new AnsiConsoleOutput()

--- a/webtau-http/src/test/java/com/twosigma/webtau/http/HttpJavaOverloadsTest.java
+++ b/webtau-http/src/test/java/com/twosigma/webtau/http/HttpJavaOverloadsTest.java
@@ -18,8 +18,7 @@ package com.twosigma.webtau.http;
 
 import org.junit.Test;
 
-import static com.twosigma.webtau.Ddjt.actual;
-import static com.twosigma.webtau.Ddjt.equal;
+import static com.twosigma.webtau.WebTauCore.*;
 import static com.twosigma.webtau.http.Http.http;
 import static com.twosigma.webtau.http.HttpOverloadsTestCommon.*;
 

--- a/webtau-http/src/test/java/com/twosigma/webtau/http/HttpJavaTest.java
+++ b/webtau-http/src/test/java/com/twosigma/webtau/http/HttpJavaTest.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static com.twosigma.webtau.Ddjt.*;
+import static com.twosigma.webtau.WebTauCore.*;
 import static com.twosigma.webtau.cfg.WebTauConfig.getCfg;
 import static com.twosigma.webtau.http.Http.http;
 

--- a/webtau-http/src/test/java/com/twosigma/webtau/http/HttpOverloadsTestCommon.java
+++ b/webtau-http/src/test/java/com/twosigma/webtau/http/HttpOverloadsTestCommon.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static com.twosigma.webtau.Ddjt.equal;
+import static com.twosigma.webtau.WebTauCore.equal;
 import static com.twosigma.webtau.http.Http.http;
 
 public class HttpOverloadsTestCommon {

--- a/webtau-json-schema/src/test/groovy/com/twosigma/webtau/expectation/schema/SchemaMatcherTest.groovy
+++ b/webtau-json-schema/src/test/groovy/com/twosigma/webtau/expectation/schema/SchemaMatcherTest.groovy
@@ -5,9 +5,7 @@ import com.twosigma.webtau.http.datanode.DataNodeId
 import com.twosigma.webtau.schema.expectation.SchemaMatcher
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.actual
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 
 class SchemaMatcherTest {
     private final static TEST_SCHEMA = "test-schema.json"

--- a/webtau-junit5/src/test/java/com/twosigma/webtau/junit5/DynamicTestsTest.groovy
+++ b/webtau-junit5/src/test/java/com/twosigma/webtau/junit5/DynamicTestsTest.groovy
@@ -18,7 +18,7 @@ package com.twosigma.webtau.junit5
 
 import org.junit.jupiter.api.Test
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 
 class DynamicTestsTest {
     @Test

--- a/webtau-open-api/src/test/groovy/com/twosigma/webtau/openapi/OpenApiResponseValidatorTest.groovy
+++ b/webtau-open-api/src/test/groovy/com/twosigma/webtau/openapi/OpenApiResponseValidatorTest.groovy
@@ -33,7 +33,7 @@ import org.junit.Test
 
 import java.nio.file.Paths
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 
 class OpenApiResponseValidatorTest implements StepReporter {
     List<String> stepMessages = []

--- a/webtau-open-api/src/test/groovy/com/twosigma/webtau/openapi/OpenApiSpecValidatorTest.groovy
+++ b/webtau-open-api/src/test/groovy/com/twosigma/webtau/openapi/OpenApiSpecValidatorTest.groovy
@@ -22,7 +22,7 @@ import com.twosigma.webtau.utils.ResourceUtils
 import org.junit.Before
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.*
+import static com.twosigma.webtau.WebTauCore.*
 
 class OpenApiSpecValidatorTest {
     private final static String GET = "GET"

--- a/webtau-pdf/src/test/groovy/com/twosigma/webtau/pdf/PdfHttpTest.groovy
+++ b/webtau-pdf/src/test/groovy/com/twosigma/webtau/pdf/PdfHttpTest.groovy
@@ -29,7 +29,7 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.contain
+import static com.twosigma.webtau.WebTauCore.contain
 import static com.twosigma.webtau.http.Http.http
 import static com.twosigma.webtau.pdf.Pdf.pdf
 

--- a/webtau-pdf/src/test/groovy/com/twosigma/webtau/pdf/PdfTest.groovy
+++ b/webtau-pdf/src/test/groovy/com/twosigma/webtau/pdf/PdfTest.groovy
@@ -23,9 +23,7 @@ import com.twosigma.webtau.http.datanode.StructuredDataNode
 import com.twosigma.webtau.utils.ResourceUtils
 import org.junit.Test
 
-import static com.twosigma.webtau.Ddjt.code
-import static com.twosigma.webtau.Ddjt.contain
-import static com.twosigma.webtau.Ddjt.throwException
+import static com.twosigma.webtau.WebTauCore.*
 import static com.twosigma.webtau.pdf.Pdf.pdf
 
 class PdfTest {

--- a/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
+++ b/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestRunnerTest.groovy
@@ -21,7 +21,7 @@ import org.junit.Test
 
 import java.nio.file.Paths
 
-import static com.twosigma.webtau.Ddjt.contain
+import static com.twosigma.webtau.WebTauCore.contain
 
 class StandaloneTestRunnerTest {
     @Test

--- a/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestTest.groovy
+++ b/webtau-standalone-runner-groovy/src/test/groovy/com/twosigma/webtau/runner/standalone/StandaloneTestTest.groovy
@@ -21,7 +21,7 @@ import org.junit.Test
 
 import java.nio.file.Paths
 
-import static com.twosigma.webtau.Ddjt.equal
+import static com.twosigma.webtau.WebTauCore.equal
 
 class StandaloneTestTest {
     @Test

--- a/webtau/src/main/java/com/twosigma/webtau/WebTauDsl.java
+++ b/webtau/src/main/java/com/twosigma/webtau/WebTauDsl.java
@@ -35,7 +35,7 @@ import com.twosigma.webtau.schema.expectation.SchemaMatcher;
 /*
 Convenient class for static * import
  */
-public class WebTauDsl extends Ddjt {
+public class WebTauDsl extends WebTauCore {
     public static final Data data = Data.data;
     public static final Cache cache = Cache.cache;
 


### PR DESCRIPTION
* `Matchers` as a separate class
* rename `Ddjt` to `WebTauCore`
* deprecate `beGreater/Less` family in favor of `shouldBe`

Note that existing class `Ddjt` is gone. It was not supposed to be used directly for `http` and `web ui` testing. 
In theory it is a backward incompatible change, but in practice it should be fine. 
I am reluctant to roll `2.x` version yet. 

Any thoughts @tsiq-clemens, @tsiq-karold?