### PR TITLE
Fix docs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,3 @@ addons:
 install: true
 
 script: mvn -B package
-
-deploy:
-  - provider: script
-    script: ./update-gh-pages.sh
-    skip_cleanup: true
-    on:
-      all_branches: true
-      tags: true

--- a/update-gh-pages.sh
+++ b/update-gh-pages.sh
@@ -27,7 +27,7 @@ rm -rf $GH_PAGES_DIR/znaisrc/*
 cp -r $ROOT_DIR/webtau-docs/target/webtau/guide/* $GH_PAGES_DIR/guide/
 cp -r $ROOT_DIR/webtau-docs/target/znaisrc/* $GH_PAGES_DIR/znaisrc/
 
-cd $GH_PAGES_DIR
+pushd $GH_PAGES_DIR
 
 # Tell git about changed, new and deleted pages
 git add -A
@@ -35,3 +35,5 @@ git add -A
 git commit -m "Updating docs for $WEBTAU_VERSION"
 git push
 
+# change back to root dir to allow cleanup to work properly
+popd

--- a/update-gh-pages.sh
+++ b/update-gh-pages.sh
@@ -24,7 +24,7 @@ rm -rf $GH_PAGES_DIR/guide/*
 rm -rf $GH_PAGES_DIR/znaisrc/*
 
 # Copy in new pages
-cp -r $ROOT_DIR/webtau-docs/target/guide/* $GH_PAGES_DIR/guide/
+cp -r $ROOT_DIR/webtau-docs/target/webtau/guide/* $GH_PAGES_DIR/guide/
 cp -r $ROOT_DIR/webtau-docs/target/znaisrc/* $GH_PAGES_DIR/znaisrc/
 
 cd $GH_PAGES_DIR

--- a/webtau-docs/pom.xml
+++ b/webtau-docs/pom.xml
@@ -84,7 +84,7 @@
                             <goal>build</goal>
                         </goals>
                         <configuration>
-                            <docId>guide</docId>
+                            <docId>webtau/guide</docId>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
1. fix doc ID; the hosted pages have a `webtau/guide` prefix
1. fix update-gh-pages script for the new doc ID
1. remove invocation of update-gh-pages from Travis branch build as it currently does not work as Travis does not have permissions to push to the branch