### PR TITLE
Build with multiple JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+jdk:
+  - openjdk8
+  - openjdk11
+
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
@tsiq-clemens has recently hit some differences between 8 and 11 in the context of the http url classes.  I'm making Travis build with both 8 and 11 in an attempt to catch such issues.

The two builds run in parallel so should not have any real impact on overall Travis build time.  Don't be confused by the time reported in Travis, that's a sum of all parallel jobs.