### PR TITLE
Introduce http listeners

### DIFF
--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/listeners/HttpListenersTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/listeners/HttpListenersTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.http.listeners
+
+import com.twosigma.webtau.http.HttpHeader
+import com.twosigma.webtau.http.HttpResponse
+import com.twosigma.webtau.http.HttpTestBase
+import com.twosigma.webtau.http.listener.HttpListener
+import com.twosigma.webtau.http.listener.HttpListeners
+import com.twosigma.webtau.http.request.HttpRequestBody
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+import static com.twosigma.webtau.Matchers.contain
+import static com.twosigma.webtau.http.Http.http
+
+class HttpListenersTest extends HttpTestBase implements HttpListener {
+    Map beforePayload
+    Map afterPayload
+
+
+    // Note that testing beforeFirstHttpCall is not done here due to implementation leveraging singleton approach to
+    // make sure callback is only called once
+
+    @Override
+    void beforeHttpCall(String requestMethod, String passedUrl, String fullUrl, HttpHeader requestHeader, HttpRequestBody requestBody) {
+        beforePayload = [
+                requestMethod: requestMethod,
+                passedUrl: passedUrl,
+                fullUrl: fullUrl,
+                requestHeader: requestHeader,
+                requestBody: requestBody
+        ]
+    }
+
+    @Override
+    void afterHttpCall(String requestMethod, String passedUrl, String fullUrl, HttpHeader requestHeader, HttpRequestBody requestBody, HttpResponse response) {
+        afterPayload = [
+                requestMethod: requestMethod,
+                passedUrl: passedUrl,
+                fullUrl: fullUrl,
+                requestHeader: requestHeader,
+                requestBody: requestBody,
+                response: response
+        ]
+    }
+
+    @Before
+    void init() {
+        HttpListeners.add(this)
+
+        beforePayload = [:]
+        afterPayload = [:]
+    }
+
+    @After
+    void cleanup() {
+        HttpListeners.remove(this)
+    }
+
+    @Test
+    void "before and after call callbacks should have essential http call info"() {
+        http.put("/end-point", http.header([custom: 'value']), [payload: 'message']) {}
+
+        validateCommonCallBackPayload(beforePayload)
+        validateCommonCallBackPayload(afterPayload)
+
+        afterPayload.response.textContent.should contain("complexList")
+        afterPayload.response.statusCode.should == 200
+    }
+
+    private static void validateCommonCallBackPayload(payload) {
+        payload.requestMethod.should == 'PUT'
+        payload.passedUrl.should == "/end-point"
+        payload.fullUrl.should == ~/^*\d\+*\/end-point$/
+        payload.requestHeader.custom.should == 'value'
+        payload.requestBody.type().should == 'application/json'
+    }
+}

--- a/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/listeners/HttpListenersTest.groovy
+++ b/webtau-http-groovy/src/test/groovy/com/twosigma/webtau/http/listeners/HttpListenersTest.groovy
@@ -33,7 +33,6 @@ class HttpListenersTest extends HttpTestBase implements HttpListener {
     Map beforePayload
     Map afterPayload
 
-
     // Note that testing beforeFirstHttpCall is not done here due to implementation leveraging singleton approach to
     // make sure callback is only called once
 

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/listener/HttpListener.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/listener/HttpListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.http.listener;
+
+import com.twosigma.webtau.http.HttpHeader;
+import com.twosigma.webtau.http.HttpResponse;
+import com.twosigma.webtau.http.request.HttpRequestBody;
+
+public interface HttpListener {
+    default void beforeFirstHttpCall() {
+    }
+
+    default void beforeHttpCall(String requestMethod,
+                                String passedUrl,
+                                String fullUrl,
+                                HttpHeader requestHeader,
+                                HttpRequestBody requestBody) {
+    }
+
+    default void afterHttpCall(String requestMethod,
+                               String passedUrl,
+                               String fullUrl,
+                               HttpHeader requestHeader,
+                               HttpRequestBody requestBody,
+                               HttpResponse response) {
+    }
+}

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/listener/HttpListener.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/listener/HttpListener.java
@@ -21,9 +21,20 @@ import com.twosigma.webtau.http.HttpResponse;
 import com.twosigma.webtau.http.request.HttpRequestBody;
 
 public interface HttpListener {
+    /**
+     * called once right before first <code>http.post|get|put|patch|delete</code> call
+     */
     default void beforeFirstHttpCall() {
     }
 
+    /**
+     * called before each http call
+     * @param requestMethod http method (e.g. POST)
+     * @param passedUrl url used in a test (e.g. /customers)
+     * @param fullUrl fully resolved url (e.g. https://my-server:3010/customers)
+     * @param requestHeader request header
+     * @param requestBody request body
+     */
     default void beforeHttpCall(String requestMethod,
                                 String passedUrl,
                                 String fullUrl,
@@ -31,6 +42,15 @@ public interface HttpListener {
                                 HttpRequestBody requestBody) {
     }
 
+    /**
+     * called after each http call
+     * @param requestMethod http method (e.g. POST)
+     * @param passedUrl url used in a test (e.g. /customers)
+     * @param fullUrl fully resolved url (e.g. https://my-server:3010/customers)
+     * @param requestHeader request header
+     * @param requestBody request body
+     * @param response response
+     */
     default void afterHttpCall(String requestMethod,
                                String passedUrl,
                                String fullUrl,

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/listener/HttpListeners.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/listener/HttpListeners.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.http.listener;
+
+import com.twosigma.webtau.http.HttpHeader;
+import com.twosigma.webtau.http.HttpResponse;
+import com.twosigma.webtau.http.request.HttpRequestBody;
+import com.twosigma.webtau.utils.ServiceLoaderUtils;
+
+import java.util.List;
+
+public class HttpListeners {
+    private static final List<HttpListener> listeners = ServiceLoaderUtils.load(HttpListener.class);
+
+    private HttpListeners() {
+    }
+
+    public static void beforeFirstHttpCall() {
+        listeners.forEach(HttpListener::beforeFirstHttpCall);
+    }
+
+    public static void beforeHttpCall(String requestMethod,
+                                      String passedUrl,
+                                      String fullUrl,
+                                      HttpHeader requestHeader,
+                                      HttpRequestBody requestBody) {
+        listeners.forEach(listener -> listener.beforeHttpCall(requestMethod, passedUrl, fullUrl, requestHeader, requestBody));
+    }
+
+    public static void afterHttpCall(String requestMethod,
+                                     String passedUrl,
+                                     String fullUrl,
+                                     HttpHeader requestHeader,
+                                     HttpRequestBody requestBody,
+                                     HttpResponse response) {
+        listeners.forEach(listener -> listener.afterHttpCall(
+                requestMethod, passedUrl, fullUrl, requestHeader, requestBody, response));
+    }
+
+    public static void add(HttpListener listener) {
+        listeners.add(listener);
+    }
+
+    public static void remove(HttpListener listener) {
+        listeners.remove(listener);
+    }
+}

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/validation/HttpValidationResult.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/validation/HttpValidationResult.java
@@ -124,6 +124,10 @@ public class HttpValidationResult implements TestStepPayload {
         return requestBody != null ? requestBody.asString() : null;
     }
 
+    public HttpRequestBody getRequestBody() {
+        return requestBody;
+    }
+
     public boolean nullOrEmptyRequestContent() {
         return StringUtils.nullOrEmpty(getRequestContent());
     }
@@ -153,7 +157,7 @@ public class HttpValidationResult implements TestStepPayload {
     }
 
     public String renderMismatches() {
-        return mismatches.stream().collect(Collectors.joining("\n"));
+        return String.join("\n", mismatches);
     }
 
     public void setErrorMessage(String errorMessage) {


### PR DESCRIPTION
```
public interface HttpListener {
    default void beforeFirstHttpCall() {
    }

    default void beforeHttpCall(String requestMethod,
                                String passedUrl,
                                String fullUrl,
                                HttpHeader requestHeader,
                                HttpRequestBody requestBody) {
    }

    default void afterHttpCall(String requestMethod,
                               String passedUrl,
                               String fullUrl,
                               HttpHeader requestHeader,
                               HttpRequestBody requestBody,
                               HttpResponse response) {
    }
}
```
`beforeFirstHttpCall` can be used to automatically bootstrap an embedded server