### PR TITLE
initial repl for groovy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,12 @@
 
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-groovysh</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-groovydoc</artifactId>
                 <version>${groovy.version}</version>
             </dependency>

--- a/webtau-browser/src/main/java/com/twosigma/webtau/browser/page/PageElement.java
+++ b/webtau-browser/src/main/java/com/twosigma/webtau/browser/page/PageElement.java
@@ -52,9 +52,12 @@ public interface PageElement extends ActualValueExpectations, WithTokenizedDescr
     boolean isVisible();
     boolean isEnabled();
     boolean isSelected();
+    boolean isPresent();
 
     String getText();
     String getUnderlyingValue();
+
+    TokenizedMessage locationDescription();
 
     void scrollIntoView();
     void highlight();

--- a/webtau-browser/src/main/java/com/twosigma/webtau/browser/page/path/GenericPageElement.java
+++ b/webtau-browser/src/main/java/com/twosigma/webtau/browser/page/path/GenericPageElement.java
@@ -45,12 +45,12 @@ import static com.twosigma.webtau.reporter.TestStep.createAndExecuteStep;
 import static com.twosigma.webtau.reporter.TokenizedMessage.tokenizedMessage;
 
 public class GenericPageElement implements PageElement {
-    private WebDriver driver;
+    private final WebDriver driver;
     private final AdditionalBrowserInteractions additionalBrowserInteractions;
-    private ElementPath path;
+    private final ElementPath path;
     private final TokenizedMessage pathDescription;
-    private ElementValue<String, PageElement> elementValue;
-    private ElementValue<Integer, PageElement> countValue;
+    private final ElementValue<String, PageElement> elementValue;
+    private final ElementValue<Integer, PageElement> countValue;
 
     public GenericPageElement(WebDriver driver, AdditionalBrowserInteractions additionalBrowserInteractions, ElementPath path) {
         this.driver = driver;
@@ -167,6 +167,12 @@ public class GenericPageElement implements PageElement {
     }
 
     @Override
+    public boolean isPresent() {
+        WebElement webElement = findElement();
+        return !(webElement instanceof NullWebElement);
+    }
+
+    @Override
     public String toString() {
         return path.toString();
     }
@@ -180,6 +186,11 @@ public class GenericPageElement implements PageElement {
     public String getUnderlyingValue() {
         List<String> values = extractValues();
         return values.isEmpty() ? null : values.get(0);
+    }
+
+    @Override
+    public TokenizedMessage locationDescription() {
+        return pathDescription;
     }
 
     @Override

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
@@ -33,14 +33,16 @@ import static com.twosigma.webtau.cfg.ConfigValue.declare;
 import static com.twosigma.webtau.cfg.ConfigValue.declareBoolean;
 
 public class WebTauConfig {
-    public static String CONFIG_FILE_NAME_DEFAULT = "webtau.cfg";
+    public static final String REPL_KEY = "repl";
+    public static final String CONFIG_FILE_NAME_DEFAULT = "webtau.cfg";
 
     private static final List<WebTauConfigHandler> handlers = discoverConfigHandlers();
 
     private static final Supplier<Object> NO_DEFAULT = () -> null;
 
     private final ConfigValue config = declare("config", "config file path", () -> CONFIG_FILE_NAME_DEFAULT);
-    private final ConfigValue interactive = declareBoolean("interactive", "use CLI interactive mode");
+    private final ConfigValue interactive = declareBoolean("interactive", "use CLI interactive mode (experimental)");
+    private final ConfigValue repl = declareBoolean(REPL_KEY, "use CLI repl mode (will scuppered interactive)");
     private final ConfigValue env = declare("env", "environment id", () -> "local");
     private final ConfigValue url = declare("url", "base url for application under test", NO_DEFAULT);
     private final ConfigValue verbosityLevel = declare("verbosityLevel", "output verbosity level. " +
@@ -147,6 +149,13 @@ public class WebTauConfig {
 
     public boolean isInteractive() {
         return interactive.getAsBoolean();
+    }
+
+    /**
+     * repl mode is going o be merged with interactive
+     */
+    public boolean isRepl() {
+        return repl.getAsBoolean();
     }
 
     public void setBaseUrl(String url) {
@@ -273,7 +282,9 @@ public class WebTauConfig {
 
     @Override
     public String toString() {
-        return enumeratedCfgValues.values().stream().map(ConfigValue::toString).collect(Collectors.joining("\n"));
+        return Stream.concat(enumeratedCfgValues.values().stream(), freeFormCfgValues.stream())
+                .map(ConfigValue::toString)
+                .collect(Collectors.joining("\n"));
     }
 
     public void print() {
@@ -346,6 +357,7 @@ public class WebTauConfig {
         Stream<ConfigValue> standardConfigValues = Stream.of(
                 config,
                 interactive,
+                repl,
                 env,
                 url,
                 verbosityLevel,

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
@@ -33,7 +33,6 @@ import static com.twosigma.webtau.cfg.ConfigValue.declare;
 import static com.twosigma.webtau.cfg.ConfigValue.declareBoolean;
 
 public class WebTauConfig {
-    public static final String REPL_KEY = "repl";
     public static final String CONFIG_FILE_NAME_DEFAULT = "webtau.cfg";
 
     private static final List<WebTauConfigHandler> handlers = discoverConfigHandlers();
@@ -41,8 +40,6 @@ public class WebTauConfig {
     private static final Supplier<Object> NO_DEFAULT = () -> null;
 
     private final ConfigValue config = declare("config", "config file path", () -> CONFIG_FILE_NAME_DEFAULT);
-    private final ConfigValue interactive = declareBoolean("interactive", "use CLI interactive mode (experimental)");
-    private final ConfigValue repl = declareBoolean(REPL_KEY, "use CLI repl mode (will replace interactive)");
     private final ConfigValue env = declare("env", "environment id", () -> "local");
     private final ConfigValue url = declare("url", "base url for application under test", NO_DEFAULT);
     private final ConfigValue verbosityLevel = declare("verbosityLevel", "output verbosity level. " +
@@ -145,17 +142,6 @@ public class WebTauConfig {
 
         registerFreeFormCfgValues(values);
         freeFormCfgValues.forEach(v -> v.accept(source, values));
-    }
-
-    public boolean isInteractive() {
-        return interactive.getAsBoolean();
-    }
-
-    /**
-     * repl mode is going to be merged with interactive
-     */
-    public boolean isRepl() {
-        return repl.getAsBoolean();
     }
 
     public void setBaseUrl(String url) {
@@ -356,8 +342,6 @@ public class WebTauConfig {
     private Map<String, ConfigValue> enumerateRegisteredConfigValues() {
         Stream<ConfigValue> standardConfigValues = Stream.of(
                 config,
-                interactive,
-                repl,
                 env,
                 url,
                 verbosityLevel,

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
@@ -152,7 +152,7 @@ public class WebTauConfig {
     }
 
     /**
-     * repl mode is going o be merged with interactive
+     * repl mode is going to be merged with interactive
      */
     public boolean isRepl() {
         return repl.getAsBoolean();

--- a/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
+++ b/webtau-config/src/main/java/com/twosigma/webtau/cfg/WebTauConfig.java
@@ -42,7 +42,7 @@ public class WebTauConfig {
 
     private final ConfigValue config = declare("config", "config file path", () -> CONFIG_FILE_NAME_DEFAULT);
     private final ConfigValue interactive = declareBoolean("interactive", "use CLI interactive mode (experimental)");
-    private final ConfigValue repl = declareBoolean(REPL_KEY, "use CLI repl mode (will scuppered interactive)");
+    private final ConfigValue repl = declareBoolean(REPL_KEY, "use CLI repl mode (will replace interactive)");
     private final ConfigValue env = declare("env", "environment id", () -> "local");
     private final ConfigValue url = declare("url", "base url for application under test", NO_DEFAULT);
     private final ConfigValue verbosityLevel = declare("verbosityLevel", "output verbosity level. " +

--- a/webtau-core/src/main/java/com/twosigma/webtau/reporter/stacktrace/StackTraceUtils.java
+++ b/webtau-core/src/main/java/com/twosigma/webtau/reporter/stacktrace/StackTraceUtils.java
@@ -36,7 +36,8 @@ public class StackTraceUtils {
             "org.codehaus.groovy",
             "org.junit",
             "com.intellij",
-            "groovy.");
+            "groovy.",
+            "groovysh_evaluate");
 
     private StackTraceUtils() {
     }
@@ -50,7 +51,9 @@ public class StackTraceUtils {
     }
 
     public static String renderStackTraceWithoutLibCalls(Throwable t) {
-        return filterStackTrace(t,  (line) -> !isStandardCall(line) && !isMoreMessage(line));
+        return filterStackTrace(t,  (line) -> !isStandardCall(line) &&
+                !isMoreMessage(line) &&
+                !isUnknownSource(line));
     }
 
     public static String fullCauseMessage(Throwable t) {
@@ -128,6 +131,10 @@ public class StackTraceUtils {
 
     private static boolean isAtLine(String stackTraceLine) {
         return stackTraceLine.trim().startsWith("at");
+    }
+
+    private static boolean isUnknownSource(String stackTraceLine) {
+        return stackTraceLine.contains("(Unknown Source)");
     }
 
     private static boolean isMoreMessage(String stackTraceLine) {

--- a/webtau-groovy/pom.xml
+++ b/webtau-groovy/pom.xml
@@ -75,6 +75,11 @@
 
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-groovysh</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-groovydoc</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/webtau-groovy/repl-demo/webtau.cfg
+++ b/webtau-groovy/repl-demo/webtau.cfg
@@ -1,0 +1,2 @@
+url = "http://localhost:8080"
+custom = 2

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
@@ -69,7 +69,9 @@ class WebTauCliArgsConfig {
 
         if (commandLine.hasOption(EXAMPLE_OPTION)) {
             scaffoldExamples()
-        } else if (commandLine.hasOption(HELP_OPTION) || commandLine.argList.isEmpty()) {
+        } else if (commandLine.hasOption(HELP_OPTION) ||
+                commandLine.argList.isEmpty() &&
+                !commandLine.hasOption(WebTauConfig.REPL_KEY)) {
             printHelp(options)
         } else {
             testFiles = new ArrayList<>(commandLine.argList)

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauCliArgsConfig.groovy
@@ -49,6 +49,14 @@ class WebTauCliArgsConfig {
         parseArgs()
     }
 
+    static boolean isReplMode(String[] args) {
+        return args.any { it == "repl" }
+    }
+
+    static boolean isInteractiveMode(String[] args) {
+        return args.any { it == "interactive" }
+    }
+
     void setConfigFileRelatedCfgIfPresent() {
         setValueFromCliIfPresent(cfg.workingDirConfigValue)
         setValueFromCliIfPresent(cfg.configFileName)
@@ -71,7 +79,7 @@ class WebTauCliArgsConfig {
             scaffoldExamples()
         } else if (commandLine.hasOption(HELP_OPTION) ||
                 commandLine.argList.isEmpty() &&
-                !commandLine.hasOption(WebTauConfig.REPL_KEY)) {
+                !isReplMode(args)) {
             printHelp(options)
         } else {
             testFiles = new ArrayList<>(commandLine.argList)

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauGroovyFileConfigHandler.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauGroovyFileConfigHandler.groovy
@@ -77,6 +77,10 @@ class WebTauGroovyFileConfigHandler implements WebTauConfigHandler {
             def parsedConfig = configSlurper.parse(configScript)
             return parsedConfig
         } catch (Throwable e) {
+            // main use case for this is during REPL mode
+            // we don't want to crash the config class loading due to parsing error
+            // because in REPL mode we should be able to recover and continue
+            // otherwise we will have to restart REPL process
             if (ignoreConfigErrors.get()) {
                 ConsoleOutputs.err(StackTraceUtils.fullCauseMessage(e))
                 return null

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauGroovyFileConfigHandler.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cfg/WebTauGroovyFileConfigHandler.groovy
@@ -76,7 +76,7 @@ class WebTauGroovyFileConfigHandler implements WebTauConfigHandler {
 
             def parsedConfig = configSlurper.parse(configScript)
             return parsedConfig
-        } catch (Throwable e) {
+        } catch (Exception e) {
             // main use case for this is during REPL mode
             // we don't want to crash the config class loading due to parsing error
             // because in REPL mode we should be able to recover and continue

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
@@ -22,6 +22,7 @@ import com.twosigma.webtau.cfg.GroovyRunner
 import com.twosigma.webtau.cfg.WebTauConfig
 import com.twosigma.webtau.cfg.WebTauGroovyCliArgsConfigHandler
 import com.twosigma.webtau.cli.interactive.WebTauCliInteractive
+import com.twosigma.webtau.cli.repl.Repl
 import com.twosigma.webtau.console.ConsoleOutput
 import com.twosigma.webtau.console.ConsoleOutputs
 import com.twosigma.webtau.console.ansi.AnsiConsoleOutput
@@ -64,7 +65,10 @@ class WebTauCliApp implements TestListener {
     static void main(String[] args) {
         def cliApp = new WebTauCliApp(args)
 
-        if (getCfg().isInteractive()) {
+        if (getCfg().isRepl()) {
+            cliApp.startRepl()
+            System.exit(0)
+        } else if (getCfg().isInteractive()) {
             cliApp.startInteractive()
             System.exit(0)
         } else {
@@ -92,6 +96,11 @@ class WebTauCliApp implements TestListener {
             def interactive = new WebTauCliInteractive(runner)
             interactive.start()
         }
+    }
+
+    void startRepl() {
+        def repl = new Repl()
+        repl.run()
     }
 
     private void prepareTestsAndRun(WebDriverBehavior webDriverBehavior, Closure code) {

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/WebTauCliApp.groovy
@@ -19,6 +19,7 @@ package com.twosigma.webtau.cli
 import com.twosigma.webtau.WebTauGroovyDsl
 import com.twosigma.webtau.browser.driver.WebDriverCreator
 import com.twosigma.webtau.cfg.GroovyRunner
+import com.twosigma.webtau.cfg.WebTauCliArgsConfig
 import com.twosigma.webtau.cfg.WebTauConfig
 import com.twosigma.webtau.cfg.WebTauGroovyCliArgsConfigHandler
 import com.twosigma.webtau.cli.interactive.WebTauCliInteractive
@@ -65,10 +66,10 @@ class WebTauCliApp implements TestListener {
     static void main(String[] args) {
         def cliApp = new WebTauCliApp(args)
 
-        if (getCfg().isRepl()) {
-            cliApp.startRepl()
+        if (WebTauCliArgsConfig.isReplMode(args)) {
+            startRepl()
             System.exit(0)
-        } else if (getCfg().isInteractive()) {
+        } else if (WebTauCliArgsConfig.isInteractiveMode(args)) {
             cliApp.startInteractive()
             System.exit(0)
         } else {
@@ -98,7 +99,7 @@ class WebTauCliApp implements TestListener {
         }
     }
 
-    void startRepl() {
+    static void startRepl() {
         def repl = new Repl()
         repl.run()
     }

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/repl/Repl.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/repl/Repl.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.repl
+
+import com.twosigma.webtau.browser.page.PageElement
+import com.twosigma.webtau.cfg.WebTauGroovyFileConfigHandler
+import com.twosigma.webtau.console.ConsoleOutputs
+import com.twosigma.webtau.console.ansi.Color
+import com.twosigma.webtau.http.datanode.DataNode
+import com.twosigma.webtau.http.render.DataNodeAnsiPrinter
+import com.twosigma.webtau.http.validation.HttpValidationHandlers
+import com.twosigma.webtau.reporter.ConsoleStepReporter
+import com.twosigma.webtau.reporter.IntegrationTestsMessageBuilder
+import com.twosigma.webtau.reporter.StepReporters
+import com.twosigma.webtau.reporter.TokenizedMessageToAnsiConverter
+import com.twosigma.webtau.reporter.stacktrace.StackTraceUtils
+import org.codehaus.groovy.tools.shell.Groovysh
+import org.codehaus.groovy.tools.shell.util.Preferences
+
+import java.util.stream.Stream
+
+class Repl {
+    private final Groovysh groovysh
+    private final TokenizedMessageToAnsiConverter toAnsiConverter
+
+
+    Repl() {
+        toAnsiConverter = IntegrationTestsMessageBuilder.getConverter()
+        initHandlers()
+        initConfig()
+        groovysh = createShell()
+    }
+
+    static void main(String[] args) {
+        def repl = new Repl()
+        repl.run()
+    }
+
+    void run() {
+        groovysh.run("")
+    }
+
+    private void initHandlers() {
+        StepReporters.add(new ConsoleStepReporter(toAnsiConverter))
+        HttpValidationHandlers.add(new ReplHttpLastValidationCapture())
+    }
+
+    private static void initConfig() {
+        WebTauGroovyFileConfigHandler.forceIgnoreErrors()
+    }
+
+    private Groovysh createShell() {
+        System.setProperty("groovysh.prompt", "webtau")
+
+        def shell = new Groovysh()
+        shell.imports << "static com.twosigma.webtau.WebTauGroovyDsl.*"
+        shell.imports << "static com.twosigma.webtau.cli.repl.ReplCommands.*"
+        shell.imports << "static com.twosigma.webtau.cli.repl.ReplHttpLastValidationCapture.*"
+        shell.errorHook = this.&errorHook
+
+        shell.resultHook = { Object result ->
+            if (result != null) {
+                renderResult(result)
+            }
+        }
+
+        return shell
+    }
+
+    private static void errorHook(Throwable error) {
+        ConsoleOutputs.err("ERROR:\n" + StackTraceUtils.renderStackTraceWithoutLibCalls(error))
+    }
+
+    private void renderResult(result) {
+        def io = groovysh.io
+
+        boolean showLastResult = !io.quiet && (io.verbose ||
+                Preferences.get(Groovysh.SHOW_LAST_RESULT_PREFERENCE_KEY, 'false'))
+
+        if (!showLastResult) {
+            return
+        }
+
+        if (result instanceof DataNode) {
+            showDataNodeResult(result)
+        } else if (result instanceof PageElement) {
+            showPageElementResult(result)
+        } else {
+            groovysh.defaultResultHook(result)
+        }
+    }
+
+    private static void showDataNodeResult(DataNode result) {
+        new DataNodeAnsiPrinter().print(result)
+    }
+
+    private void showPageElementResult(PageElement pageElement) {
+        if (!pageElement.isPresent()) {
+            ConsoleOutputs.out(Stream.concat(
+                    Stream.of(Color.RED, "element is not present: "),
+                    toAnsiConverter.convert(pageElement.locationDescription()).stream()).toArray())
+            return
+        }
+
+        ConsoleOutputs.out(Stream.concat(
+                Stream.of(Color.GREEN, "element is found: "),
+                toAnsiConverter.convert(pageElement.locationDescription()).stream()).toArray())
+
+        ConsoleOutputs.out(Color.YELLOW, "           getText(): ", Color.GREEN, pageElement.getText())
+        ConsoleOutputs.out(Color.YELLOW, "getUnderlyingValue(): ", Color.GREEN, pageElement.getUnderlyingValue())
+        def count = pageElement.count.get()
+        if (count > 1) {
+            ConsoleOutputs.out(Color.YELLOW, "               count: ", Color.GREEN, count)
+        }
+
+        pageElement.highlight()
+    }
+}

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/repl/ReplCommands.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/repl/ReplCommands.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.repl
+
+import com.twosigma.webtau.cfg.WebTauConfig
+
+class ReplCommands {
+    static WebTauConfig getReloadConfig() {
+        return reloadConfig()
+    }
+
+    static WebTauConfig reloadConfig() {
+        WebTauConfig.resetConfigHandlers()
+        WebTauConfig.getCfg().reset()
+        WebTauConfig.getCfg().triggerConfigHandlers()
+
+        return WebTauConfig.cfg
+    }
+}

--- a/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/repl/ReplHttpLastValidationCapture.groovy
+++ b/webtau-groovy/src/main/groovy/com/twosigma/webtau/cli/repl/ReplHttpLastValidationCapture.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.webtau.cli.repl
+
+import com.twosigma.webtau.http.datanode.GroovyDataNode
+import com.twosigma.webtau.http.validation.HttpValidationHandler
+import com.twosigma.webtau.http.validation.HttpValidationResult
+
+class ReplHttpLastValidationCapture implements HttpValidationHandler {
+    static GroovyDataNode header
+    static GroovyDataNode body
+
+    @Override
+    void validate(HttpValidationResult validationResult) {
+        header = new GroovyDataNode(validationResult.headerNode)
+        body = new GroovyDataNode(validationResult.bodyNode)
+    }
+}

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/Http.java
@@ -700,7 +700,7 @@ public class Http {
             } catch (Throwable e) {
                 validationResult.setErrorMessage(StackTraceUtils.fullCauseMessage(e));
                 throw new HttpException("error during http." + validationResult.getRequestMethod().toLowerCase() + "(" +
-                        validationResult.getFullUrl() + ")", e);
+                        validationResult.getFullUrl() + "): " + StackTraceUtils.fullCauseMessage(e), e);
             } finally {
                 HttpListeners.afterHttpCall(validationResult.getRequestMethod(),
                         validationResult.getUrl(), validationResult.getFullUrl(),

--- a/webtau-http/src/main/java/com/twosigma/webtau/http/validation/HttpValidationHandlers.java
+++ b/webtau-http/src/main/java/com/twosigma/webtau/http/validation/HttpValidationHandlers.java
@@ -27,6 +27,14 @@ public class HttpValidationHandlers {
     private static final List<HttpValidationHandler> globalHandlers = ServiceLoaderUtils.load(HttpValidationHandler.class);
     private static final ThreadLocal<List<HttpValidationHandler>> localHandlers = ThreadLocal.withInitial(ArrayList::new);
 
+    public static void add(HttpValidationHandler handler) {
+        globalHandlers.add(handler);
+    }
+
+    public static void remove(HttpValidationHandler handler) {
+        globalHandlers.remove(handler);
+    }
+
     public static <R> R withAdditionalHandler(HttpValidationHandler handler, Supplier<R> code) {
         try {
             addLocal(handler);


### PR DESCRIPTION
Wraps groovysh to expose webtau entities like `http.` and `browser.`. 
This is for interactive exploration of REST API or browser based testing.
Eventually it will merge `interactive` mode functionality in it and `interactive` mode will be removed. 